### PR TITLE
feat(oracle): claim culprit validator if part3 returned 152 exit code

### DIFF
--- a/oracle/internal/dkg/dkg_executor.go
+++ b/oracle/internal/dkg/dkg_executor.go
@@ -366,6 +366,10 @@ func (e *Executor) executeR3(dkg *coordinator.DKG, validatorIdx uint16) bool {
 		e.sessionPublicKey,
 		e.artifacts.r3.publicKeyPackage,
 	); err != nil {
+		exitCode, _ := helpers.ExtractExitCode(err.Error())
+		if exitCode == helpers.TvmExitCodeDifferentPubkeyPackages {
+			e.claimCulpritByR3Mask(dkg, validatorIdx)
+		}
 		e.logSendPubkeyPackageFailed(dkg, err)
 	}
 	return false
@@ -380,22 +384,23 @@ func (e *Executor) executeClaim(dkg *coordinator.DKG, validatorIdx uint16, culpr
 	}
 
 	e.logMessage(dkg, fmt.Sprintf("sending claim packages. Culprit validator idx: %d", culpritIdx))
-	withErrors := false
-
-	// claim package is not sent yet, send it to coordinator
 	_, err := e.coordinatorContract.SendDKGClaim(
 		validatorIdx,
 		dkg.Until.Unix(),
 		culpritIdx,
 	)
 	if err != nil {
-		e.logSendClaimPackage(dkg, culpritIdx, err)
-		withErrors = true
-	}
-
-	if withErrors {
-		e.logError(dkg, "claim packages sent with errors", nil)
+		e.logSendClaimFailed(dkg, culpritIdx, err)
 	} else {
 		e.logDKGProcess(dkg, "claim packages sent")
+	}
+}
+
+func (e *Executor) claimCulpritByR3Mask(dkg *coordinator.DKG, validatorIdx uint16) {
+	for i := uint16(0); i < dkg.MaxSigners; i++ {
+		if dkg.R3.Mask.Bit(int(i)) > 0 {
+			e.executeClaim(dkg, validatorIdx, i)
+			return
+		}
 	}
 }

--- a/oracle/internal/dkg/dkg_executor_feedback.go
+++ b/oracle/internal/dkg/dkg_executor_feedback.go
@@ -92,7 +92,7 @@ func (e *Executor) logSendRound2Package(dkg *coordinator.DKG, toIdx uint16, err 
 		Msg("failed to send round2 package: " + msg)
 }
 
-func (e *Executor) logSendClaimPackage(dkg *coordinator.DKG, culpritIdx uint16, err error) {
+func (e *Executor) logSendClaimFailed(dkg *coordinator.DKG, culpritIdx uint16, err error) {
 	msg := helpers.HandleTvmError(err)
 
 	errorEventWithDkg(dkg).

--- a/oracle/internal/helpers.go
+++ b/oracle/internal/helpers.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rsquad/ton-teleport-btc-periphery/lib/pkg/logger"
 )
 
+const TvmExitCodeDifferentPubkeyPackages = 152
+
 // Helpers
 
 func ConvertMapToFrostPackages(origMap map[uint16][]byte) (frostMap map[frost.Identifier]frost.Package) {


### PR DESCRIPTION
- Added constant for TVM exit code related to different public key packages.
- Renamed logSendClaimPackage to logSendClaimFailed for clarity.
- Updated executeR3 to handle specific exit code and claim culprit by R3 mask.
- Improved logging for claim package sending errors.