### PR TITLE
fix(pegoutcontract): update InternalKey assignment to use FillBytes

### DIFF
--- a/lib/pkg/ton/pegoutcontract/pegout_contract.go
+++ b/lib/pkg/ton/pegoutcontract/pegout_contract.go
@@ -93,7 +93,7 @@ func (c *PegoutContract) GetTxParts(block *ton.BlockIDExt) (*TxParts, error) {
 		Inputs:      inputs,
 		Outputs:     outputs,
 		Signatures:  signatures,
-		InternalKey: internalKey.Bytes(),
+		InternalKey: internalKey.FillBytes(make([]byte, 32)),
 	}, nil
 }
 


### PR DESCRIPTION
…or consistent byte length