### PR TITLE
TOB-TGBTC-8

### DIFF
--- a/lib/pkg/ton/coordinator/coordinator_contract.go
+++ b/lib/pkg/ton/coordinator/coordinator_contract.go
@@ -48,24 +48,28 @@ type Coordinator interface {
 
 	SendCommitments(
 		pegoutID uint64,
+		pegoutUntil int64,
 		validatorIdx uint16,
 		commitments []byte,
 	) (*tlb.Transaction, error)
 
 	SendSigningShare(
 		pegoutID uint64,
+		pegoutUntil int64,
 		validatorIdx uint16,
 		signingShares [][]byte,
 	) (*tlb.Transaction, error)
 
 	SendSignatures(
 		pegoutID uint64,
+		pegoutUntil int64,
 		validatorIdx uint16,
 		signatures [][]byte,
 	) (*tlb.Transaction, error)
 
 	SendSigningClaim(
 		pegoutID uint64,
+		pegoutUntil int64,
 		validatorIdx uint16,
 		culpritIdx uint16,
 	) (*tlb.Transaction, error)

--- a/lib/pkg/ton/coordinator/msgs.go
+++ b/lib/pkg/ton/coordinator/msgs.go
@@ -54,6 +54,7 @@ func BuildSendCommitmentsBody(ttl int64, req *CommitmentRequest) *cell.Cell {
 		MustStoreUInt(uint64(time.Now().Unix()+ttl), 32).
 		MustStoreUInt(uint64(req.ValidatorIdx), 16).
 		MustStoreUInt(req.PegoutID, 64).
+		MustStoreUInt(uint64(req.PegoutUntil), 32).
 		MustStoreRef(utils.SplitBytesToCells(req.Commitments)).
 		EndCell()
 }
@@ -72,6 +73,7 @@ func BuildSendSigningShareBody(ttl int64, req *SigningShareRequest) *cell.Cell {
 		MustStoreUInt(uint64(time.Now().Unix()+ttl), 32).
 		MustStoreUInt(uint64(req.ValidatorIdx), 16).
 		MustStoreUInt(req.PegoutID, 64).
+		MustStoreUInt(uint64(req.PegoutUntil), 32).
 		MustStoreRef(dict.AsCell()).
 		EndCell()
 }
@@ -90,6 +92,7 @@ func BuildSendSignaturesBody(ttl int64, req *SignaturesRequest) *cell.Cell {
 		MustStoreUInt(uint64(time.Now().Unix()+ttl), 32).
 		MustStoreUInt(uint64(req.ValidatorIdx), 16).
 		MustStoreUInt(req.PegoutID, 64).
+		MustStoreUInt(uint64(req.PegoutUntil), 32).
 		MustStoreRef(dict.AsCell()).
 		EndCell()
 }
@@ -100,6 +103,7 @@ func BuildSendSigningClaimBody(ttl int64, req *SigningClaimRequest) *cell.Cell {
 		MustStoreUInt(uint64(time.Now().Unix()+ttl), 32).
 		MustStoreUInt(uint64(req.ValidatorIdx), 16).
 		MustStoreUInt(req.PegoutID, 64).
+		MustStoreUInt(uint64(req.PegoutUntil), 32).
 		MustStoreUInt(uint64(req.culpritIdx), 16).
 		EndCell()
 }

--- a/lib/pkg/ton/coordinator/operations.go
+++ b/lib/pkg/ton/coordinator/operations.go
@@ -78,6 +78,7 @@ func (c *coordinatorContract) SendPubkeyPackage(
 
 func (c *coordinatorContract) SendCommitments(
 	PegoutID uint64,
+	PegoutUntil int64,
 	ValidatorIdx uint16,
 	Commitments []byte,
 ) (*tlb.Transaction, error) {
@@ -86,40 +87,43 @@ func (c *coordinatorContract) SendCommitments(
 	}
 	return c.sendBodyCell(BuildSendCommitmentsBody(
 		int64(c.ttl.Seconds()),
-		&CommitmentRequest{PegoutID, ValidatorIdx, Commitments},
+		&CommitmentRequest{PegoutID, PegoutUntil, ValidatorIdx, Commitments},
 	), "SendCommitments")
 }
 
 func (c *coordinatorContract) SendSigningShare(
 	PegoutID uint64,
+	PegoutUntil int64,
 	ValidatorIdx uint16,
 	SigningShares [][]byte,
 ) (*tlb.Transaction, error) {
 	return c.sendBodyCell(BuildSendSigningShareBody(
 		int64(c.ttl.Seconds()),
-		&SigningShareRequest{PegoutID, ValidatorIdx, SigningShares},
+		&SigningShareRequest{PegoutID, PegoutUntil, ValidatorIdx, SigningShares},
 	), "SendSigningShare")
 }
 
 func (c *coordinatorContract) SendSignatures(
 	PegoutID uint64,
+	PegoutUntil int64,
 	ValidatorIdx uint16,
 	Signatures [][]byte,
 ) (*tlb.Transaction, error) {
 	return c.sendBodyCell(BuildSendSignaturesBody(
 		int64(c.ttl.Seconds()),
-		&SignaturesRequest{PegoutID, ValidatorIdx, Signatures},
+		&SignaturesRequest{PegoutID, PegoutUntil, ValidatorIdx, Signatures},
 	), "SendSignatures")
 }
 
 func (c *coordinatorContract) SendSigningClaim(
 	PegoutID uint64,
+	PegoutUntil int64,
 	ValidatorIdx uint16,
 	culpritIdx uint16,
 ) (*tlb.Transaction, error) {
 	return c.sendBodyCell(BuildSendSigningClaimBody(
 		int64(c.ttl.Seconds()),
-		&SigningClaimRequest{PegoutID, ValidatorIdx, culpritIdx},
+		&SigningClaimRequest{PegoutID, PegoutUntil, ValidatorIdx, culpritIdx},
 	), "SendSigningClaim")
 }
 

--- a/lib/pkg/ton/coordinator/types.go
+++ b/lib/pkg/ton/coordinator/types.go
@@ -96,24 +96,28 @@ func (dkg *DKG) CheckVSetMask(validatorIdx uint16) bool {
 // CommitmentRequest represents a request to send commitments
 type CommitmentRequest struct {
 	PegoutID     uint64
+	PegoutUntil  int64
 	ValidatorIdx uint16
 	Commitments  []byte
 }
 
 type SigningShareRequest struct {
 	PegoutID      uint64
+	PegoutUntil   int64
 	ValidatorIdx  uint16
 	SigningShares [][]byte
 }
 
 type SignaturesRequest struct {
 	PegoutID     uint64
+	PegoutUntil  int64
 	ValidatorIdx uint16
 	Signatures   [][]byte
 }
 
 type SigningClaimRequest struct {
 	PegoutID     uint64
+	PegoutUntil  int64
 	ValidatorIdx uint16
 	culpritIdx   uint16
 }

--- a/oracle/internal/signing/service.go
+++ b/oracle/internal/signing/service.go
@@ -268,16 +268,7 @@ func (s *SignService) doCommit(
 		}
 	}
 
-	s.logSendCommitments(pegout.ID, commitments)
-	if _, err := s.coordinator.SendCommitments(
-		pegout.ID,
-		validatorIdx,
-		commitments,
-	); err != nil {
-		s.logSendCommitmentsError(pegout.ID, err)
-	} else {
-		s.logCommitSent(pegout.ID)
-	}
+	s.sendCommitments(pegout, validatorIdx, commitments)
 
 	return false
 }
@@ -345,16 +336,7 @@ func (s *SignService) doSign(
 		s.keyStore.StoreSigningShares(pegout.addrStr, signShares)
 	}
 
-	s.logSendSigningShare(pegout.ID, signShares)
-	if _, err := s.coordinator.SendSigningShare(
-		pegout.ID,
-		validatorIdx,
-		signShares,
-	); err != nil {
-		s.logSendSigningShareError(pegout.ID, err)
-	} else {
-		s.logSigningShareSent(pegout.ID)
-	}
+	s.sendSigningShares(pegout, validatorIdx, signShares)
 
 	return false
 }
@@ -403,13 +385,41 @@ func (s *SignService) doAggregate(
 	s.SendSignatures(pegout, validatorIdx, signatures)
 }
 
+func (s *SignService) sendCommitments(pegout *CachedPegout, validatorIdx uint16, commitments []byte) {
+	s.logSendCommitments(pegout.ID, commitments)
+	if _, err := s.coordinator.SendCommitments(
+		pegout.ID,
+		pegout.artifacts.ExpiredAt.Unix(),
+		validatorIdx,
+		commitments,
+	); err != nil {
+		s.logSendCommitmentsError(pegout.ID, err)
+	} else {
+		s.logCommitSent(pegout.ID)
+	}
+}
+
+func (s *SignService) sendSigningShares(pegout *CachedPegout, validatorIdx uint16, signShares [][]byte) {
+	s.logSendSigningShare(pegout.ID, signShares)
+	if _, err := s.coordinator.SendSigningShare(
+		pegout.ID,
+		pegout.artifacts.ExpiredAt.Unix(),
+		validatorIdx,
+		signShares,
+	); err != nil {
+		s.logSendSigningShareError(pegout.ID, err)
+	} else {
+		s.logSigningShareSent(pegout.ID)
+	}
+}
+
 func (s *SignService) SendSignatures(pegout *CachedPegout, validatorIdx uint16, signatures [][]byte) int {
 	_, err := s.coordinator.SendSignatures(
 		pegout.ID,
+		pegout.artifacts.ExpiredAt.Unix(),
 		validatorIdx,
 		signatures,
 	)
-
 	if err != nil {
 		exitCode, _ := helpers.ExtractExitCode(err.Error())
 		if exitCode == helpers.DifferentPegoutSignatures {
@@ -495,6 +505,7 @@ func (s *SignService) executeClaim(pegout *CachedPegout, validatorIdx uint16, cu
 
 	if _, err := s.coordinator.SendSigningClaim(
 		pegout.ID,
+		pegout.artifacts.ExpiredAt.Unix(),
 		validatorIdx,
 		culpritIdx,
 	); err != nil {

--- a/oracle/internal/signing/service_test.go
+++ b/oracle/internal/signing/service_test.go
@@ -1,10 +1,12 @@
 package signing
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/rsquad/ton-teleport-btc-periphery/lib/pkg/ton/coordinator"
 	"github.com/rsquad/ton-teleport-btc-periphery/lib/pkg/ton/pegoutcontract"
@@ -32,7 +34,7 @@ func newCoordinatorContractMock() *coordinator.CoordinatorMock {
 		GetUnsignedPegoutsFunc: func() ([]coordinator.PegoutRecord, error) {
 			panic("mock out the GetUnsignedPegouts method")
 		},
-		SendCommitmentsFunc: func(pegoutID uint64, validatorIdx uint16, commitments []byte) (*tlb.Transaction, error) {
+		SendCommitmentsFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, commitments []byte) (*tlb.Transaction, error) {
 			panic("mock out the SendCommitments method")
 		},
 		SendDKGClaimFunc: func(validatorIdx uint16, dkgUntil int64, culpritIdx uint16) (*tlb.Transaction, error) {
@@ -50,7 +52,7 @@ func newCoordinatorContractMock() *coordinator.CoordinatorMock {
 		SendRound2Func: func(validatorIdx uint16, dkgUntil int64, round2Packages []byte) (*tlb.Transaction, error) {
 			panic("mock out the SendRound2 method")
 		},
-		SendSignaturesFunc: func(pegoutID uint64, validatorIdx uint16, signatures [][]byte) (*tlb.Transaction, error) {
+		SendSignaturesFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, signatures [][]byte) (*tlb.Transaction, error) {
 			if validatorIdx == 1 {
 				// Emulate an error (err::different_pegout_signatures = 168) during the coordinator contract call
 				return nil, errors.New("...exitcode=168...")
@@ -59,7 +61,7 @@ func newCoordinatorContractMock() *coordinator.CoordinatorMock {
 			// Emulate a successful send signatures to the coordinator contract
 			return nil, nil
 		},
-		SendSigningClaimFunc: func(pegoutID uint64, validatorIdx uint16, culpritIdx uint16) (*tlb.Transaction, error) {
+		SendSigningClaimFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, culpritIdx uint16) (*tlb.Transaction, error) {
 			if validatorIdx != 1 {
 				panic(fmt.Sprintf("Wrong validatorIdx: expected 1, but got %d", validatorIdx))
 			}
@@ -71,7 +73,7 @@ func newCoordinatorContractMock() *coordinator.CoordinatorMock {
 			// Emulate a successful send claim to the coordinator contract
 			return nil, nil
 		},
-		SendSigningShareFunc: func(pegoutID uint64, validatorIdx uint16, signingShares [][]byte) (*tlb.Transaction, error) {
+		SendSigningShareFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, signingShares [][]byte) (*tlb.Transaction, error) {
 			panic("mock out the SendSigningShare method")
 		},
 		SendStartDKGFunc: func() (*tlb.Transaction, error) {
@@ -122,4 +124,65 @@ func TestSignService_SendSignatures_ERROR_DifferentPegoutSignatures(t *testing.T
 	if resCode != helpers.DifferentPegoutSignatures {
 		t.Fatalf("expected resCode = %d (DifferentPegoutSignatures), got %d", helpers.DifferentPegoutSignatures, resCode)
 	}
+}
+
+func TestPegoutUntil(t *testing.T) {
+	pegout := &CachedPegout{
+		ID:            1,
+		addrStr:       "",
+		inputs:        []pegoutcontract.TxInput{},
+		tx:            nil,
+		signingHashes: [][]byte{},
+		artifacts: &coordinator.PegoutRecord{
+			ExpiredAt:  time.Unix(100000000, 0),
+			ClaimsMask: big.NewInt(0),
+		},
+	}
+
+	validateExpiredAt := func(pegout *CachedPegout, pegoutUntil int64) {
+		if pegout.artifacts.ExpiredAt.Unix() != pegoutUntil {
+			t.Fatalf("Wrong pegoutUntil: expected %d, but got %d", pegout.artifacts.ExpiredAt.Unix(), pegoutUntil)
+		}
+	}
+
+	coordinator := &coordinator.CoordinatorMock{
+		SendCommitmentsFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, commitments []byte) (*tlb.Transaction, error) {
+			validateExpiredAt(pegout, pegoutUntil)
+			return nil, nil
+		},
+		SendSigningShareFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, signingShares [][]byte) (*tlb.Transaction, error) {
+			validateExpiredAt(pegout, pegoutUntil)
+			return nil, nil
+		},
+		SendSignaturesFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, signatures [][]byte) (*tlb.Transaction, error) {
+			validateExpiredAt(pegout, pegoutUntil)
+			return nil, nil
+		},
+		SendSigningClaimFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, culpritIdx uint16) (*tlb.Transaction, error) {
+			validateExpiredAt(pegout, pegoutUntil)
+			return nil, nil
+		},
+	}
+
+	service := NewService(nil, coordinator, nil, 0)
+	validatorIdx := uint16(0)
+
+	commitments := make([]byte, 32)
+	rand.Read(commitments)
+
+	service.sendCommitments(pegout, validatorIdx, commitments)
+
+	signShares := make([][]byte, 1)
+	signShares[0] = make([]byte, 32)
+	rand.Read(signShares[0])
+
+	service.sendSigningShares(pegout, validatorIdx, signShares)
+
+	signatures := make([][]byte, 1)
+	signatures[0] = make([]byte, 64)
+	rand.Read(signatures[0])
+
+	service.SendSignatures(pegout, validatorIdx, signatures)
+
+	service.executeClaim(pegout, validatorIdx, 1)
 }


### PR DESCRIPTION
- Updated SendCommitments, SendSigningShare, SendSignatures, and SendSigningClaim methods of coordinator contract to accept a new pegoutUntil parameter.
- Modified corresponding request structures (CommitmentRequest, SigningShareRequest, SignaturesRequest, SigningClaimRequest) to include pegoutUntil.
- Adjusted body building functions to store pegoutUntil in the transaction body.
- Updated oracle SignService to pass pegoutUntil of cached pegout to coordinator Send*** methods.