### PR TITLE
TOB-TGBTC-16

### DIFF
--- a/oracle/internal/helpers.go
+++ b/oracle/internal/helpers.go
@@ -13,10 +13,12 @@ import (
 	"github.com/rsquad/ton-teleport-btc-periphery/lib/pkg/logger"
 )
 
-const TvmExitCodeDifferentPubkeyPackages = 152
-const FrostDkgR2PackageSize = 37 /*FROST R2 package to single validator*/
-const EncryptedFrostDkgR2PackageSize = 24 /*nonce for encryption*/ + 16 /*encryption header*/ + FrostDkgR2PackageSize
-const SizeOfSingleDkgR2Package = 2 /*ToValidatorId*/ + EncryptedFrostDkgR2PackageSize
+const (
+	TvmExitCodeDifferentPubkeyPackages = 152
+	FrostDkgR2PackageSize              = 37 /*FROST R2 package to single validator*/
+	EncryptedFrostDkgR2PackageSize     = 24 /*nonce for encryption*/ + 16 /*encryption header*/ + FrostDkgR2PackageSize
+	SizeOfSingleDkgR2Package           = 2 /*ToValidatorId*/ + EncryptedFrostDkgR2PackageSize
+)
 
 // Helpers
 
@@ -63,7 +65,8 @@ func DeserializeDkgR2(r2Packages map[uint16][]byte /*map[FROM]data*/, vsetMask *
 	map[uint16]map[uint16][]byte, /*map[FROM]map[TO]data*/
 	bool, /*is culprit was found*/
 	uint16, /*culprit*/
-	error) {
+	error,
+) {
 	deserializedData := make(map[uint16]map[uint16][]byte)
 
 	for fromValidatorIdx, serializedToPkgs := range r2Packages {
@@ -113,6 +116,74 @@ func DeserializeDkgR2(r2Packages map[uint16][]byte /*map[FROM]data*/, vsetMask *
 	}
 
 	return deserializedData, false, 0, nil
+}
+
+func SerializeCommitments(commitments [][]byte) []byte {
+	serialized := []byte{}
+	serialized = append(serialized, byte(len(commitments)))
+	for _, commitment := range commitments {
+		serialized = append(serialized, byte(len(commitment)))
+		serialized = append(serialized, commitment...)
+	}
+	return serialized
+}
+
+func DeserializeCommitments(serialized []byte, expectedCount int) ([][]byte, error) {
+	if len(serialized) == 0 {
+		return nil, errors.New("serialized commitments data is empty")
+	}
+
+	commitments := [][]byte{}
+	commitmentsCount := int(serialized[0])
+
+	if commitmentsCount != expectedCount {
+		return nil, fmt.Errorf("incorrect number of commitments: expected %d, got %d", expectedCount, commitmentsCount)
+	}
+
+	offset := 1
+	for i := 0; i < commitmentsCount; i++ {
+		// Check if we have enough bytes to read the commitment length
+		if offset >= len(serialized) {
+			return nil, fmt.Errorf("insufficient data: cannot read commitment %d length", i)
+		}
+		commitmentLen := int(serialized[offset])
+		offset += 1
+
+		// Check if we have enough bytes to read the commitment data
+		if offset+commitmentLen > len(serialized) {
+			return nil, fmt.Errorf("insufficient data: cannot read commitment %d (expected %d bytes, have %d)", i, commitmentLen, len(serialized)-offset)
+		}
+
+		// Validate commitment length is reasonable (prevent excessive memory allocation)
+		if commitmentLen > 256 {
+			return nil, fmt.Errorf("commitment %d length %d exceeds maximum allowed size", i, commitmentLen)
+		}
+
+		commitment := make([]byte, commitmentLen)
+		copy(commitment, serialized[offset:offset+commitmentLen])
+		commitments = append(commitments, commitment)
+		offset += commitmentLen
+	}
+
+	return commitments, nil
+}
+
+// Deserializes only 1 commitment with index `inputIndex` for every validator
+func DeserializeInputCommitmentForAll(
+	validatorCommitments map[uint16][]byte, // all commitments for all validators
+	totalInputs int, // total number of inputs in pegout transaction - used for validation
+	inputIndex int, // pegout transaction input index for which we need to deserialize commitments
+) (map[uint16][]byte, error) {
+	commitmentsMap := make(map[uint16][]byte)
+	// for each validator, deserialize all commitments and return the commitment for the inputIndex
+	for validatorIdx, serializedCommitments := range validatorCommitments {
+		commitments, err := DeserializeCommitments(serializedCommitments, totalInputs)
+		if err != nil {
+			return nil, err
+		}
+		commitmentsMap[validatorIdx] = commitments[inputIndex]
+	}
+	return commitmentsMap, nil
 }
 
 func ConvertMapToFrostPackages(origMap map[uint16][]byte) (frostMap map[frost.Identifier]frost.Package) {

--- a/oracle/internal/helpers.go
+++ b/oracle/internal/helpers.go
@@ -162,6 +162,10 @@ func DeserializeInputCommitmentForAll(
 	totalInputs int, // total number of inputs in pegout transaction - used for validation
 	inputIndex int, // pegout transaction input index for which we need to deserialize commitments
 ) (map[uint16][]byte, error) {
+	if inputIndex < 0 || inputIndex >= totalInputs {
+		return nil, fmt.Errorf("inputIndex is out of range: %d", inputIndex)
+	}
+
 	commitmentsMap := make(map[uint16][]byte)
 	// for each validator, deserialize all commitments and return the commitment for the inputIndex
 	for validatorIdx, serializedCommitments := range validatorCommitments {

--- a/oracle/internal/helpers.go
+++ b/oracle/internal/helpers.go
@@ -18,6 +18,7 @@ const (
 	FrostDkgR2PackageSize              = 37 /*FROST R2 package to single validator*/
 	EncryptedFrostDkgR2PackageSize     = 24 /*nonce for encryption*/ + 16 /*encryption header*/ + FrostDkgR2PackageSize
 	SizeOfSingleDkgR2Package           = 2 /*ToValidatorId*/ + EncryptedFrostDkgR2PackageSize
+	FrostCommitmentLength              = 71
 )
 
 // Helpers
@@ -118,17 +119,19 @@ func DeserializeDkgR2(r2Packages map[uint16][]byte /*map[FROM]data*/, vsetMask *
 	return deserializedData, false, 0, nil
 }
 
-func SerializeCommitments(commitments [][]byte) []byte {
+func SerializeCommitments(commitments [][]byte, expectedLength int) ([]byte, error) {
 	serialized := []byte{}
 	serialized = append(serialized, byte(len(commitments)))
 	for _, commitment := range commitments {
-		serialized = append(serialized, byte(len(commitment)))
+		if len(commitment) != expectedLength {
+			return nil, fmt.Errorf("commitment length %d is not equal to %d", len(commitment), FrostCommitmentLength)
+		}
 		serialized = append(serialized, commitment...)
 	}
-	return serialized
+	return serialized, nil
 }
 
-func DeserializeCommitments(serialized []byte, expectedCount int) ([][]byte, error) {
+func DeserializeCommitments(serialized []byte, expectedCount int, expectedLength int) ([][]byte, error) {
 	if len(serialized) == 0 {
 		return nil, errors.New("serialized commitments data is empty")
 	}
@@ -140,29 +143,14 @@ func DeserializeCommitments(serialized []byte, expectedCount int) ([][]byte, err
 		return nil, fmt.Errorf("incorrect number of commitments: expected %d, got %d", expectedCount, commitmentsCount)
 	}
 
-	offset := 1
+	if len(serialized) < 1+commitmentsCount*expectedLength {
+		return nil, fmt.Errorf("insufficient data: cannot read commitments (expected %d bytes, have %d)", 1+commitmentsCount*expectedLength, len(serialized))
+	}
+
 	for i := 0; i < commitmentsCount; i++ {
-		// Check if we have enough bytes to read the commitment length
-		if offset >= len(serialized) {
-			return nil, fmt.Errorf("insufficient data: cannot read commitment %d length", i)
-		}
-		commitmentLen := int(serialized[offset])
-		offset += 1
-
-		// Check if we have enough bytes to read the commitment data
-		if offset+commitmentLen > len(serialized) {
-			return nil, fmt.Errorf("insufficient data: cannot read commitment %d (expected %d bytes, have %d)", i, commitmentLen, len(serialized)-offset)
-		}
-
-		// Validate commitment length is reasonable (prevent excessive memory allocation)
-		if commitmentLen > 256 {
-			return nil, fmt.Errorf("commitment %d length %d exceeds maximum allowed size", i, commitmentLen)
-		}
-
-		commitment := make([]byte, commitmentLen)
-		copy(commitment, serialized[offset:offset+commitmentLen])
+		commitment := make([]byte, expectedLength)
+		copy(commitment, serialized[1+i*expectedLength:1+(i+1)*expectedLength])
 		commitments = append(commitments, commitment)
-		offset += commitmentLen
 	}
 
 	return commitments, nil
@@ -177,7 +165,7 @@ func DeserializeInputCommitmentForAll(
 	commitmentsMap := make(map[uint16][]byte)
 	// for each validator, deserialize all commitments and return the commitment for the inputIndex
 	for validatorIdx, serializedCommitments := range validatorCommitments {
-		commitments, err := DeserializeCommitments(serializedCommitments, totalInputs)
+		commitments, err := DeserializeCommitments(serializedCommitments, totalInputs, FrostCommitmentLength)
 		if err != nil {
 			return nil, err
 		}

--- a/oracle/internal/helpers_test.go
+++ b/oracle/internal/helpers_test.go
@@ -352,6 +352,24 @@ func TestDeserializeCommitments(t *testing.T) {
 				}
 			}
 		})
+
+		t.Run("DeserializeInputCommitmentForAll", func(t *testing.T) {
+			commitsMap := map[uint16][]byte{0: generateCommitment(0), 1: generateCommitment(1), 2: generateCommitment(2)}
+			result, err := DeserializeInputCommitmentForAll(commitsMap, 3, -1)
+			if err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if result != nil {
+				t.Errorf("expected nil but got %v", result)
+			}
+			result, err = DeserializeInputCommitmentForAll(commitsMap, 3, 3)
+			if err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if result != nil {
+				t.Errorf("expected nil but got %v", result)
+			}
+		})
 	}
 }
 

--- a/oracle/internal/helpers_test.go
+++ b/oracle/internal/helpers_test.go
@@ -124,3 +124,309 @@ func TestExtractExitCode(t *testing.T) {
 		})
 	}
 }
+
+func generateCommitment(idx int) []byte {
+	commitment := make([]byte, FrostCommitmentLength)
+	for i := range commitment {
+		commitment[i] = byte((idx + i) % 256)
+	}
+	return commitment
+}
+
+func TestSerializeCommitments(t *testing.T) {
+	commitment1 := generateCommitment(0)
+	commitment2 := generateCommitment(1)
+	commitment3 := generateCommitment(2)
+
+	serialized3 := append([]byte{3}, commitment1...)
+	serialized3 = append(serialized3, commitment2...)
+	serialized3 = append(serialized3, commitment3...)
+
+	tests := []struct {
+		name        string
+		commitments [][]byte
+		expected    []byte
+		expectError bool
+	}{
+		{
+			name:        "Empty commitments",
+			commitments: [][]byte{},
+			expected:    []byte{0}, // count = 0
+			expectError: false,
+		},
+		{
+			name:        "Single commitment with correct length",
+			commitments: [][]byte{commitment1},
+			expected:    append([]byte{1}, commitment1...), // count=1, then commitment
+			expectError: false,
+		},
+		{
+			name: "Multiple commitments with correct length",
+			commitments: [][]byte{
+				commitment1,
+				commitment2,
+				commitment3,
+			},
+			expected:    serialized3, // count=3, then 3 commitments
+			expectError: false,
+		},
+		{
+			name:        "Commitment with incorrect length should return error",
+			commitments: [][]byte{{0x01, 0x02, 0x03}}, // wrong length
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "Zero length commitment should return error",
+			commitments: [][]byte{{}}, // wrong length
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := SerializeCommitments(tt.commitments, FrostCommitmentLength)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("SerializeCommitments() expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("SerializeCommitments() unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("SerializeCommitments() length = %d, expected %d", len(result), len(tt.expected))
+				return
+			}
+			for i, b := range result {
+				if b != tt.expected[i] {
+					t.Errorf("SerializeCommitments() byte %d = %d, expected %d", i, b, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDeserializeCommitments(t *testing.T) {
+	commitment1 := generateCommitment(0)
+	commitment2 := generateCommitment(1)
+	commitment3 := generateCommitment(2)
+
+	serialized3 := append([]byte{3}, commitment1...)
+	serialized3 = append(serialized3, commitment2...)
+	serialized3 = append(serialized3, commitment3...)
+
+	serialized2 := append([]byte{2}, commitment1...)
+	serialized2 = append(serialized2, commitment2...)
+
+	tests := []struct {
+		name          string
+		serialized    []byte
+		expectedCount int
+		expected      [][]byte
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "Empty serialized data",
+			serialized:    []byte{},
+			expectedCount: 0,
+			expected:      nil,
+			expectError:   true,
+			errorContains: "serialized commitments data is empty",
+		},
+		{
+			name:          "Single commitment",
+			serialized:    append([]byte{1}, commitment1...),
+			expectedCount: 1,
+			expected:      [][]byte{commitment1},
+			expectError:   false,
+		},
+		{
+			name:          "Multiple commitments",
+			serialized:    serialized3,
+			expectedCount: 3,
+			expected:      [][]byte{commitment1, commitment2, commitment3},
+			expectError:   false,
+		},
+		{
+			name:          "Zero commitments",
+			serialized:    []byte{0},
+			expectedCount: 0,
+			expected:      [][]byte{},
+			expectError:   false,
+		},
+		{
+			name:          "Incorrect count - expected more",
+			serialized:    append([]byte{1}, commitment1...),
+			expectedCount: 2,
+			expected:      nil,
+			expectError:   true,
+			errorContains: "incorrect number of commitments: expected 2, got 1",
+		},
+		{
+			name:          "Incorrect count - expected less",
+			serialized:    serialized2,
+			expectedCount: 1,
+			expected:      nil,
+			expectError:   true,
+			errorContains: "incorrect number of commitments: expected 1, got 2",
+		},
+		{
+			name:          "Insufficient data for commitments",
+			serialized:    append([]byte{2}, commitment1...), // says 2 commitments but only has data for 1
+			expectedCount: 2,
+			expected:      nil,
+			expectError:   true,
+			errorContains: "insufficient data: cannot read commitments",
+		},
+		{
+			name:          "Partial commitment data",
+			serialized:    append([]byte{1}, commitment1[:len(commitment1)-1]...),
+			expectedCount: 1,
+			expected:      nil,
+			expectError:   true,
+			errorContains: "insufficient data: cannot read commitments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Initialize test data in serialized commitments
+			if !tt.expectError && len(tt.serialized) > 1 {
+				count := int(tt.serialized[0])
+				for i := 0; i < count; i++ {
+					for j := 0; j < FrostCommitmentLength; j++ {
+						tt.serialized[1+i*FrostCommitmentLength+j] = byte((i + j) % 256)
+					}
+				}
+			}
+
+			// Initialize expected result with the same test data
+			if !tt.expectError && len(tt.expected) > 0 {
+				for i, commitment := range tt.expected {
+					for j := range commitment {
+						commitment[j] = byte((i + j) % 256)
+					}
+				}
+			}
+
+			result, err := DeserializeCommitments(tt.serialized, tt.expectedCount, FrostCommitmentLength)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("DeserializeCommitments() expected error but got none")
+					return
+				}
+				if tt.errorContains != "" && !containsString(err.Error(), tt.errorContains) {
+					t.Errorf("DeserializeCommitments() error = %v, expected to contain %q", err, tt.errorContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("DeserializeCommitments() unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("DeserializeCommitments() length = %d, expected %d", len(result), len(tt.expected))
+				return
+			}
+
+			for i, commitment := range result {
+				if len(commitment) != FrostCommitmentLength {
+					t.Errorf("DeserializeCommitments() commitment %d length = %d, expected %d", i, len(commitment), FrostCommitmentLength)
+					continue
+				}
+				for j, b := range commitment {
+					if b != tt.expected[i][j] {
+						t.Errorf("DeserializeCommitments() commitment %d byte %d = %d, expected %d", i, j, b, tt.expected[i][j])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSerializeDeserializeCommitments_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		commitments [][]byte
+	}{
+		{
+			name:        "Empty commitments",
+			commitments: [][]byte{},
+		},
+		{
+			name:        "Single commitment",
+			commitments: [][]byte{generateCommitment(0)},
+		},
+		{
+			name: "Multiple commitments",
+			commitments: [][]byte{
+				generateCommitment(0),
+				generateCommitment(1),
+				generateCommitment(2),
+				generateCommitment(3),
+				generateCommitment(4),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Serialize
+			serialized, err := SerializeCommitments(tt.commitments, FrostCommitmentLength)
+			if err != nil {
+				t.Errorf("SerializeCommitments() unexpected error: %v", err)
+				return
+			}
+
+			// Deserialize
+			result, err := DeserializeCommitments(serialized, len(tt.commitments), FrostCommitmentLength)
+			if err != nil {
+				t.Errorf("DeserializeCommitments() unexpected error: %v", err)
+				return
+			}
+
+			// Compare
+			if len(result) != len(tt.commitments) {
+				t.Errorf("Round trip failed: length = %d, expected %d", len(result), len(tt.commitments))
+				return
+			}
+
+			for i, commitment := range result {
+				if len(commitment) != FrostCommitmentLength {
+					t.Errorf("Round trip failed: commitment %d length = %d, expected %d", i, len(commitment), FrostCommitmentLength)
+					continue
+				}
+				for j, b := range commitment {
+					if b != tt.commitments[i][j] {
+						t.Errorf("Round trip failed: commitment %d byte %d = %d, expected %d", i, j, b, tt.commitments[i][j])
+					}
+				}
+			}
+		})
+	}
+}
+
+// Helper function to check if a string contains a substring
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr ||
+			func() bool {
+				for i := 0; i <= len(s)-len(substr); i++ {
+					if s[i:i+len(substr)] == substr {
+						return true
+					}
+				}
+				return false
+			}())))
+}

--- a/oracle/internal/keystore/keystore.go
+++ b/oracle/internal/keystore/keystore.go
@@ -14,13 +14,9 @@ import (
 type Keystore interface {
 	LoadSecret(pubkey []byte) []byte
 	LoadSession(dkgUntilTimestamp int64) []byte
-	LoadNonce(name string) []byte
-	LoadCommitments(name string) []byte
 	LoadSigningShares(name string) [][]byte
 	StoreSecret(pubkey []byte, secret []byte) error
 	StoreSession(dkgUntilTimestamp int64, secret []byte) error
-	StoreNonce(name string, nonce []byte) error
-	StoreCommitments(name string, commitments []byte) error
 	StoreSigningShares(name string, pkgs [][]byte) error
 	Cleanup()
 }
@@ -73,14 +69,6 @@ func (ks *FileKeystore) LoadSession(dkgUntilTimestamp int64) []byte {
 	return ks.load("sessions", fileName)
 }
 
-func (ks *FileKeystore) LoadNonce(name string) []byte {
-	return ks.load("temp", "nonce_"+name)
-}
-
-func (ks *FileKeystore) LoadCommitments(name string) []byte {
-	return ks.load("temp", "commitments_"+name)
-}
-
 func (ks *FileKeystore) LoadSigningShares(name string) [][]byte {
 	data := ks.load("temp", "shares_"+name)
 	if data == nil {
@@ -120,16 +108,6 @@ func (ks *FileKeystore) StoreSession(dkgUntilTimestamp int64, secret []byte) err
 	fileName := fmt.Sprintf("%d", dkgUntilTimestamp)
 	filePath := filepath.Join(ks.rootPath, "sessions", fileName)
 	return ks.write(filePath, secret)
-}
-
-func (ks *FileKeystore) StoreNonce(name string, nonce []byte) error {
-	filePath := filepath.Join(ks.rootPath, "temp", "nonce_"+name)
-	return ks.write(filePath, nonce)
-}
-
-func (ks *FileKeystore) StoreCommitments(name string, commitments []byte) error {
-	filePath := filepath.Join(ks.rootPath, "temp", "commitments_"+name)
-	return ks.write(filePath, commitments)
 }
 
 func (ks *FileKeystore) StoreSigningShares(name string, pkgs [][]byte) error {

--- a/oracle/internal/signing/logging.go
+++ b/oracle/internal/signing/logging.go
@@ -58,9 +58,9 @@ func (s *SignService) logOracleEvictedFromSigning(pegoutID uint64) {
 	errorEvent().Err(err)
 }
 
-func (s *SignService) logErrNullNonceOrCommitments(nonce []byte, commitments []byte, pegoutAddrStr string) {
+func (s *SignService) logErrNullNonceOrCommitments(nonces [][]byte, commitments [][]byte, pegoutAddrStr string) {
 	var err error = nil
-	if nonce == nil {
+	if nonces == nil {
 		err = fmt.Errorf("failed to load nonce for %s", pegoutAddrStr)
 	} else if commitments == nil {
 		err = fmt.Errorf("failed to load commitments for %s", pegoutAddrStr)
@@ -105,8 +105,8 @@ func (s *SignService) logErrNothingToSign(pegoutID uint64) {
 	errorEventWithPegoutID(pegoutID).Msg("pegout has no signing hashes")
 }
 
-func (s *SignService) logAggregateSignShares(pegoutID uint64) {
-	infoEventWithPegoutID(pegoutID).Msg("Aggregate sign shares")
+func (s *SignService) logAggregateSignShares() {
+	infoEventWithPegoutID(s.cachedPegout.ID).Msg("Aggregate sign shares")
 }
 
 func (s *SignService) logSignatureSent(pegoutID uint64) {
@@ -117,12 +117,16 @@ func (s *SignService) logSignatureSendError(err error) {
 	errorEvent().Err(err).Msg("failed to send signatures")
 }
 
-func (s *SignService) logAggregateSignSharesError(err error) {
-	errorEvent().Err(err).Msg("failed to aggregate sign shares")
+func (s *SignService) logSignError(inputIndex int, err error) {
+	errorEvent().Err(err).Msgf("failed to generate signing share for input %d", inputIndex)
 }
 
-func (s *SignService) logSendCommitments(pegoutID uint64, commitments []byte) {
-	infoEventWithPegoutID(pegoutID).Msgf("send commitments: %x", commitments)
+func (s *SignService) logAggregateSignSharesError(inputIndex int, err error) {
+	errorEvent().Err(err).Msgf("failed to aggregate signature for input %d", inputIndex)
+}
+
+func (s *SignService) logSendCommitments(pegoutID uint64) {
+	infoEventWithPegoutID(pegoutID).Msg("send commitments")
 }
 
 func (s *SignService) logSendSigningShare(pegoutID uint64, signShares [][]byte) {

--- a/oracle/internal/signing/logging.go
+++ b/oracle/internal/signing/logging.go
@@ -58,16 +58,6 @@ func (s *SignService) logOracleEvictedFromSigning(pegoutID uint64) {
 	errorEvent().Err(err)
 }
 
-func (s *SignService) logErrNullNonceOrCommitments(nonces [][]byte, commitments [][]byte, pegoutAddrStr string) {
-	var err error = nil
-	if nonces == nil {
-		err = fmt.Errorf("failed to load nonce for %s", pegoutAddrStr)
-	} else if commitments == nil {
-		err = fmt.Errorf("failed to load commitments for %s", pegoutAddrStr)
-	}
-	errorEvent().Err(err)
-}
-
 func (s *SignService) logErrNoOracleCommitments(pegoutID uint64) {
 	err := fmt.Errorf("oracle didn't send commitment and cannot participate in signing for pegout %x", pegoutID)
 	errorEvent().Err(err)

--- a/oracle/internal/signing/service.go
+++ b/oracle/internal/signing/service.go
@@ -274,7 +274,11 @@ func (s *SignService) doCommit(
 		}
 	}
 
-	packedCommitments := helpers.SerializeCommitments(pegout.commitments)
+	packedCommitments, err := helpers.SerializeCommitments(pegout.commitments, helpers.FrostCommitmentLength)
+	if err != nil {
+		s.logError("failed to serialize commitments", err)
+		return false
+	}
 	s.logSendCommitments(pegout.ID)
 	if _, err := s.coordinator.SendCommitments(
 		pegout.ID,

--- a/oracle/internal/signing/service.go
+++ b/oracle/internal/signing/service.go
@@ -257,21 +257,10 @@ func (s *SignService) doCommit(
 		return false
 	}
 
-	if pegout.nonces == nil || pegout.commitments == nil {
-		// If both nonce & commitments are not found in keystore
-		if pegout.nonces == nil && pegout.commitments == nil {
-			s.logMessage("generate commitments")
-			nonces, commitments, err := s.Commit(pegout.tx.InternalKey, len(pegout.inputs))
-			if err != nil {
-				s.logError("commit error", err)
-				return false
-			}
-			pegout.nonces = nonces
-			pegout.commitments = commitments
-		} else {
-			s.logErrNullNonceOrCommitments(pegout.nonces, pegout.commitments, pegout.addrStr)
-			return false
-		}
+	err := s.generateCommitments()
+	if err != nil {
+		s.logError("failed to generate commitments", err)
+		return false
 	}
 
 	packedCommitments, err := helpers.SerializeCommitments(pegout.commitments, helpers.FrostCommitmentLength)
@@ -384,6 +373,29 @@ func (s *SignService) doAggregate(
 	} else {
 		s.logSignatureSent(pegout.ID)
 	}
+}
+
+func (s *SignService) generateCommitments() error {
+	pegout := s.cachedPegout
+	if pegout.nonces == nil || pegout.commitments == nil {
+		// If both nonce & commitments are not found in keystore
+		if pegout.nonces == nil && pegout.commitments == nil {
+			s.logMessage("generate commitments")
+			nonces, commitments, err := s.Commit(pegout.tx.InternalKey, len(pegout.inputs))
+			if err != nil {
+				return fmt.Errorf("commit error: %w", err)
+			}
+			pegout.nonces = nonces
+			pegout.commitments = commitments
+		} else {
+			if pegout.nonces == nil {
+				return fmt.Errorf("failed to load nonce for %s", pegout.addrStr)
+			} else if pegout.commitments == nil {
+				return fmt.Errorf("failed to load commitments for %s", pegout.addrStr)
+			}
+		}
+	}
+	return nil
 }
 
 func (s *SignService) SignInput(validatorIdx uint16, inputIndex int) ([]byte, error) {

--- a/oracle/internal/signing/service.go
+++ b/oracle/internal/signing/service.go
@@ -27,6 +27,8 @@ type CachedPegout struct {
 	tx            *pegoutcontract.TxParts
 	signingHashes [][]byte
 	artifacts     *coordinator.PegoutRecord
+	nonces        [][]byte
+	commitments   [][]byte
 }
 
 type SignService struct {
@@ -81,6 +83,15 @@ func (s *SignService) Work(ctx context.Context, wg *sync.WaitGroup) {
 
 func (s *SignService) cachePegoutClear() {
 	s.cachedPegout = nil
+}
+
+func (s *SignService) cleanupNonces() {
+	// zeroize nonces for security reasons
+	for i := range s.cachedPegout.nonces {
+		// fill with zeros
+		copy(s.cachedPegout.nonces[i], make([]byte, len(s.cachedPegout.nonces[i])))
+	}
+	s.cachedPegout.nonces = nil
 }
 
 func (s *SignService) cachePegout(
@@ -222,18 +233,18 @@ func (s *SignService) execute(ctx context.Context, dkg *coordinator.DKG) {
 	}
 
 	// Execute signing steps
-	if s.doCommit(validatorIdx, cachedPegout, minSigners) {
-		if s.doSign(validatorIdx, cachedPegout, minSigners) {
-			s.doAggregate(validatorIdx, cachedPegout, pubkeyPackage)
+	if s.doCommit(validatorIdx, minSigners) {
+		if s.doSign(validatorIdx, minSigners) {
+			s.doAggregate(validatorIdx, pubkeyPackage)
 		}
 	}
 }
 
 func (s *SignService) doCommit(
 	validatorIdx uint16,
-	pegout *CachedPegout,
 	minSigners uint16,
 ) bool {
+	pegout := s.cachedPegout
 	s.logCommitPegout(pegout.ID)
 
 	if pegout.artifacts.HasCommitment(validatorIdx) {
@@ -246,32 +257,29 @@ func (s *SignService) doCommit(
 		return false
 	}
 
-	nonces := s.keyStore.LoadNonce(pegout.addrStr)
-	commitments := s.keyStore.LoadCommitments(pegout.addrStr)
-
-	if nonces == nil || commitments == nil {
+	if pegout.nonces == nil || pegout.commitments == nil {
 		// If both nonce & commitments are not found in keystore
-		if nonces == nil && commitments == nil {
+		if pegout.nonces == nil && pegout.commitments == nil {
 			s.logMessage("generate commitments")
-			var err error
-			nonces, commitments, err = s.Commit(pegout.tx.InternalKey)
+			nonces, commitments, err := s.Commit(pegout.tx.InternalKey, len(pegout.inputs))
 			if err != nil {
 				s.logError("commit error", err)
 				return false
 			}
-			s.keyStore.StoreNonce(pegout.addrStr, nonces)
-			s.keyStore.StoreCommitments(pegout.addrStr, commitments)
+			pegout.nonces = nonces
+			pegout.commitments = commitments
 		} else {
-			s.logErrNullNonceOrCommitments(nonces, commitments, pegout.addrStr)
+			s.logErrNullNonceOrCommitments(pegout.nonces, pegout.commitments, pegout.addrStr)
 			return false
 		}
 	}
 
-	s.logSendCommitments(pegout.ID, commitments)
+	packedCommitments := helpers.SerializeCommitments(pegout.commitments)
+	s.logSendCommitments(pegout.ID)
 	if _, err := s.coordinator.SendCommitments(
 		pegout.ID,
 		validatorIdx,
-		commitments,
+		packedCommitments,
 	); err != nil {
 		s.logError("failed to send commitments", err)
 	} else {
@@ -283,9 +291,9 @@ func (s *SignService) doCommit(
 
 func (s *SignService) doSign(
 	validatorIdx uint16,
-	pegout *CachedPegout,
 	minSigners uint16,
 ) bool {
+	pegout := s.cachedPegout
 	s.logSignPegout(pegout.ID)
 
 	if !pegout.artifacts.HasCommitment(validatorIdx) {
@@ -315,30 +323,16 @@ func (s *SignService) doSign(
 		// Call frost.Sign for each signing hash
 		s.logMessage("generate signing share")
 
-		// Public key (X coord) used to get secret package from keystore
-		publicKey := pegout.tx.InternalKey
 		// array with sign shares for each signing hash
 		signShares = make([][]byte, 0, len(pegout.signingHashes))
 		// generate signing share for each input
-		for i, input := range pegout.inputs {
-			signShare, culpritFrostIdx, err := s.Sign(
-				publicKey,                    // public key
-				input.Data.BitcoinMerkleRoot, // tap merkle root used as tweak for tweaking signing share
-				pegout.signingHashes[i],      // signing hash for current input
-				pegout.artifacts.Commitments, // oracle's commitments to sign pegout hashes
-				pegout.addrStr,               // pegout address used as key to load nonce from keystore
-			)
+		for i := range pegout.inputs {
+			// generate signing share for the i-th input
+			signShare, err := s.SignInput(validatorIdx, i)
 			if err != nil {
-				if culpritFrostIdx != nil {
-					culpritIdx := helpers.FrostToValidatorIdx(*culpritFrostIdx)
-					s.logError(fmt.Sprintf("Sign failed. Culprit validator found: %d", culpritIdx), err)
-					s.executeClaim(pegout, validatorIdx, culpritIdx)
-				} else {
-					s.logError(fmt.Sprintf("failed to sign hash %d", i), err)
-				}
+				s.logSignError(i, err)
 				return false
 			}
-
 			signShares = append(signShares, signShare)
 		}
 		s.keyStore.StoreSigningShares(pegout.addrStr, signShares)
@@ -360,35 +354,20 @@ func (s *SignService) doSign(
 
 func (s *SignService) doAggregate(
 	validatorIdx uint16,
-	pegout *CachedPegout,
 	pubkeyPackage []byte,
 ) {
-	s.logAggregateSignShares(pegout.ID)
+	pegout := s.cachedPegout
+	s.logAggregateSignShares()
+	s.cleanupNonces()
 
-	commitmentsPackages := helpers.ConvertMapToFrostPackages(pegout.artifacts.Commitments)
 	signatures := make([][]byte, 0, len(pegout.signingHashes))
 
-	for i, input := range pegout.inputs {
-		hashOnlyShares := filterSharesByHashIndex(pegout.artifacts.SigningShares, uint16(i))
-		tapTweak := input.Data.BitcoinMerkleRoot
-		signature, culpritFrostIdx, err := frost.AggregateWithTweak(
-			pegout.signingHashes[i],
-			commitmentsPackages,
-			hashOnlyShares,
-			frost.NewPackage(pubkeyPackage),
-			tapTweak,
-		)
+	for i := range pegout.inputs {
+		signature, err := s.aggregateSignatureForInput(i, validatorIdx, pubkeyPackage)
 		if err != nil {
-			if culpritFrostIdx != nil {
-				culpritIdx := helpers.FrostToValidatorIdx(*culpritFrostIdx)
-				s.logError(fmt.Sprintf("AggregateWithTweak failed. Culprit validator found: %d", culpritIdx), err)
-				s.executeClaim(pegout, validatorIdx, culpritIdx)
-			} else {
-				s.logAggregateSignSharesError(err)
-			}
+			s.logAggregateSignSharesError(i, err)
 			return
 		}
-
 		signatures = append(signatures, signature)
 	}
 
@@ -403,36 +382,82 @@ func (s *SignService) doAggregate(
 	}
 }
 
-func (s *SignService) Sign(
-	publicKey []byte,
-	tapTweak []byte,
-	signingHash []byte,
-	commitments map[uint16][]byte,
-	nonceName string,
-) ([]byte, *frost.Identifier, error) {
+func (s *SignService) SignInput(validatorIdx uint16, inputIndex int) ([]byte, error) {
+	pegout := s.cachedPegout
+	// Public key (X coord) used to get secret package from keystore
+	publicKey := s.cachedPegout.tx.InternalKey
+
+	// get commitments from all validators for the inputIndex
+	inputCommitments, err := helpers.DeserializeInputCommitmentForAll(pegout.artifacts.Commitments, len(pegout.inputs), inputIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize input commitments: %w", err)
+	}
+
 	secretPackage := s.keyStore.LoadSecret(publicKey)
 	if secretPackage == nil {
-		return nil, nil, fmt.Errorf("failed to load secret package by key %X", publicKey)
+		return nil, fmt.Errorf("failed to load secret package by key %X", publicKey)
 	}
-	nonces := s.keyStore.LoadNonce(nonceName)
-	if nonces == nil {
-		return nil, nil, fmt.Errorf("failed to load nonce by name %s", nonceName)
-	}
-	return frost.SignWithTweak(
+	share, culpritFrostIdx, err := frost.SignWithTweak(
 		frost.NewPackage(secretPackage),
-		signingHash,
-		helpers.ConvertMapToFrostPackages(commitments),
-		frost.NewPackage(nonces),
-		tapTweak,
+		pegout.signingHashes[inputIndex],
+		helpers.ConvertMapToFrostPackages(inputCommitments),
+		frost.NewPackage(pegout.nonces[inputIndex]),
+		pegout.inputs[inputIndex].Data.BitcoinMerkleRoot,
 	)
+	if err != nil {
+		if culpritFrostIdx != nil {
+			culpritIdx := helpers.FrostToValidatorIdx(*culpritFrostIdx)
+			s.logError(fmt.Sprintf("Culprit validator found: %d", culpritIdx), err)
+			s.executeClaim(pegout, validatorIdx, culpritIdx)
+		}
+		return nil, err
+	}
+	return share, nil
 }
 
-func (s *SignService) Commit(publicKey []byte) ([]byte, []byte, error) {
+func (s *SignService) Commit(publicKey []byte, inputsCount int) ([][]byte, [][]byte, error) {
 	secretPackage := s.keyStore.LoadSecret(publicKey)
 	if secretPackage == nil {
 		return nil, nil, fmt.Errorf("failed to load secret package by key %X", publicKey)
 	}
-	return frost.Commit(frost.NewPackage(secretPackage))
+	nonces := make([][]byte, inputsCount)
+	commitments := make([][]byte, inputsCount)
+	var err error
+	frostPackage := frost.NewPackage(secretPackage)
+	for i := 0; i < inputsCount; i++ {
+		nonces[i], commitments[i], err = frost.Commit(frostPackage)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return nonces, commitments, nil
+}
+
+func (s *SignService) aggregateSignatureForInput(inputIndex int, validatorIdx uint16, pubkeyPackage []byte) ([]byte, error) {
+	pegout := s.cachedPegout
+	inputCommitments, err := helpers.DeserializeInputCommitmentForAll(pegout.artifacts.Commitments, len(pegout.inputs), inputIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize input commitments for input %d: %w", inputIndex, err)
+	}
+	commitmentsPackages := helpers.ConvertMapToFrostPackages(inputCommitments)
+	hashOnlyShares := filterSharesByHashIndex(pegout.artifacts.SigningShares, uint16(inputIndex))
+	tapTweak := pegout.inputs[inputIndex].Data.BitcoinMerkleRoot
+	signature, culpritFrostIdx, err := frost.AggregateWithTweak(
+		pegout.signingHashes[inputIndex],
+		commitmentsPackages,
+		hashOnlyShares,
+		frost.NewPackage(pubkeyPackage),
+		tapTweak,
+	)
+	if err != nil {
+		if culpritFrostIdx != nil {
+			culpritIdx := helpers.FrostToValidatorIdx(*culpritFrostIdx)
+			s.logError(fmt.Sprintf("Culprit validator found: %d", culpritIdx), err)
+			s.executeClaim(pegout, validatorIdx, culpritIdx)
+		}
+		return nil, err
+	}
+	return signature, nil
 }
 
 //

--- a/oracle/internal/signing/service.go
+++ b/oracle/internal/signing/service.go
@@ -86,10 +86,16 @@ func (s *SignService) cachePegoutClear() {
 }
 
 func (s *SignService) cleanupNonces() {
-	// zeroize nonces for security reasons
+	if s.cachedPegout == nil || s.cachedPegout.nonces == nil {
+		return
+	}
+
 	for i := range s.cachedPegout.nonces {
-		// fill with zeros
-		copy(s.cachedPegout.nonces[i], make([]byte, len(s.cachedPegout.nonces[i])))
+		if s.cachedPegout.nonces[i] != nil {
+			for j := range s.cachedPegout.nonces[i] {
+				s.cachedPegout.nonces[i][j] = 0
+			}
+		}
 	}
 	s.cachedPegout.nonces = nil
 }

--- a/oracle/internal/signing/service_test.go
+++ b/oracle/internal/signing/service_test.go
@@ -259,4 +259,13 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("Cleanup nonces", func(t *testing.T) {
+		service.cleanupNonces()
+		if service.cachedPegout.nonces != nil {
+			t.Fatal("nonces should be nil")
+		}
+		// call again to be sure the code doesn't panic
+		service.cleanupNonces()
+	})
 }

--- a/oracle/internal/signing/service_test.go
+++ b/oracle/internal/signing/service_test.go
@@ -131,14 +131,6 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 		LoadSecretFunc: func(pubKey []byte) []byte {
 			return keyPackages[0]
 		},
-		StoreNonceFunc: func(name string, nonce []byte) error {
-			t.Fatal("StoreNonceFunc should not be called")
-			return nil
-		},
-		LoadNonceFunc: func(name string) []byte {
-			t.Fatal("LoadNonceFunc should not be called")
-			return nil
-		},
 	}
 
 	coordinator := &coordinator.CoordinatorMock{
@@ -246,7 +238,7 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 		return commitments
 	}
 
-	t.Run("doSign: deserialize commitments", func(t *testing.T) {
+	t.Run("signInput: deserialize commitments", func(t *testing.T) {
 		commitmentsFor1Serialized, err := helpers.SerializeCommitments(generateCommitments(1, 2), helpers.FrostCommitmentLength)
 		if err != nil {
 			t.Fatal(err)

--- a/oracle/internal/signing/service_test.go
+++ b/oracle/internal/signing/service_test.go
@@ -1,0 +1,197 @@
+package signing
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/rsquad/ton-teleport-btc-periphery/frost"
+	"github.com/rsquad/ton-teleport-btc-periphery/lib/pkg/ton/coordinator"
+	"github.com/rsquad/ton-teleport-btc-periphery/lib/pkg/ton/pegoutcontract"
+	helpers "github.com/rsquad/ton-teleport-btc-periphery/oracle/internal"
+	"github.com/rsquad/ton-teleport-btc-periphery/oracle/internal/keystore"
+	"github.com/xssnick/tonutils-go/address"
+	"github.com/xssnick/tonutils-go/tlb"
+)
+
+func generateFrostKey(minSigners uint16, maxSigners uint16) (map[uint16][]byte, []byte) {
+	r1Secrets := make(map[frost.Identifier]uintptr)
+	r2Secrets := make(map[frost.Identifier]uintptr)
+	receivedR1Packages := make(map[frost.Identifier]map[frost.Identifier]frost.Package)
+	receivedR2Packages := make(map[frost.Identifier]map[frost.Identifier]frost.Package)
+
+	frostIdentifiers := make([]frost.Identifier, maxSigners)
+	for i := uint16(0); i < maxSigners; i++ {
+		frostIdentifiers[i] = helpers.ValidatorIdxToFrost(i)
+	}
+
+	for _, id := range frostIdentifiers {
+		pkg, secret, err := frost.DkgPart1(id, minSigners, maxSigners)
+		if err != nil {
+			panic(err)
+		}
+		r1Secrets[id] = secret
+		for _, destId := range frostIdentifiers {
+			if id != destId {
+				pkgs, ok := receivedR1Packages[destId]
+				if !ok {
+					pkgs = make(map[frost.Identifier]frost.Package)
+				}
+				pkgs[id] = frost.NewPackage(pkg)
+				receivedR1Packages[destId] = pkgs
+			}
+		}
+	}
+
+	for _, id := range frostIdentifiers {
+		secret := r1Secrets[id]
+		r2Packages, r2secret, _, err := frost.DkgPart2(secret, receivedR1Packages[id])
+		if err != nil {
+			panic(err)
+		}
+		frost.FreeR1Secret(secret)
+		delete(r1Secrets, id)
+		r2Secrets[id] = r2secret
+		for destId, r2package := range r2Packages {
+			pkgs, ok := receivedR2Packages[destId]
+			if !ok {
+				pkgs = make(map[frost.Identifier]frost.Package)
+			}
+			pkgs[id] = r2package
+			receivedR2Packages[destId] = pkgs
+		}
+	}
+
+	keyPackages := make(map[uint16][]byte)
+	publicKeyPackage := []byte{}
+	for _, id := range frostIdentifiers {
+		keyPackage, pubPackage, _, err := frost.DkgPart3(
+			r2Secrets[id],
+			receivedR1Packages[id],
+			receivedR2Packages[id],
+		)
+		frost.FreeR2Secret(r2Secrets[id])
+		delete(r2Secrets, id)
+		if err != nil {
+			panic(err)
+		}
+		keyPackages[helpers.FrostToValidatorIdx(id)] = keyPackage
+		publicKeyPackage = pubPackage
+	}
+
+	return keyPackages, publicKeyPackage
+}
+
+func TestServiceGenerateCommitmentsForEachInput(t *testing.T) {
+	maxSigners := uint16(3)
+	minSigners := uint16(2)
+	keyPackages, publicKeyPackage := generateFrostKey(minSigners, maxSigners)
+	groupPublicKey, err := frost.ExtractPublicKeyFromPackage(publicKeyPackage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pegout := &CachedPegout{
+		ID:      1,
+		addrStr: address.NewAddress(0, 0, make([]byte, 32)).String(),
+		inputs: []pegoutcontract.TxInput{{
+			TxHash: make([]byte, 32),
+			Data: &pegoutcontract.TxPartsInput{
+				Amount: big.NewInt(10000),
+				Index:  0,
+			},
+		}, {
+			TxHash: make([]byte, 32),
+			Data: &pegoutcontract.TxPartsInput{
+				Amount: big.NewInt(20000),
+				Index:  1,
+			},
+		}},
+		tx: &pegoutcontract.TxParts{
+			InternalKey: groupPublicKey,
+		},
+		artifacts: &coordinator.PegoutRecord{
+			Commitments:     map[uint16][]byte{},
+			CommitmentsMask: make([]byte, 32),
+			MaxSigners:      maxSigners,
+			ExpiredAt:       time.Now().Add(time.Minute),
+			SigningMask:     big.NewInt(7),
+		},
+	}
+
+	keystore := &keystore.KeystoreMock{
+		LoadSecretFunc: func(pubKey []byte) []byte {
+			return keyPackages[0]
+		},
+		StoreNonceFunc: func(name string, nonce []byte) error {
+			t.Fatal("StoreNonceFunc should not be called")
+			return nil
+		},
+		LoadNonceFunc: func(name string) []byte {
+			t.Fatal("LoadNonceFunc should not be called")
+			return nil
+		},
+	}
+
+	coordinator := &coordinator.CoordinatorMock{
+		SendCommitmentsFunc: func(pegoutID uint64, validatorIdx uint16, commitments []byte) (*tlb.Transaction, error) {
+			if validatorIdx != 0 {
+				t.Fatal("validatorIdx should be 0")
+			}
+			pegout.artifacts.Commitments[validatorIdx] = commitments
+			pegout.artifacts.CommitmentsMask = []byte{1}
+			pegout.artifacts.SigningMask = big.NewInt(1)
+			return nil, nil
+		},
+		GetPrevDKGFunc: func() (*coordinator.DKG, error) {
+			return &coordinator.DKG{
+				State: coordinator.DKGStateFinished,
+				VSet: coordinator.VSet{
+					0: make([]byte, 32),
+					1: make([]byte, 32),
+					2: make([]byte, 32),
+				},
+				MaxSigners: maxSigners,
+				VSetMask:   big.NewInt(1<<maxSigners - 1),
+				SessionKeys: &coordinator.SessionKeys{
+					PubKeys: coordinator.SessionPubKeys{
+						0: make([]byte, 32),
+						1: make([]byte, 32),
+						2: make([]byte, 32),
+					},
+				},
+				Until: time.Now().Add(time.Hour),
+				R3: &coordinator.DKGR3{
+					Mask:  big.NewInt(1<<maxSigners - 1),
+					Count: maxSigners,
+					Data: &coordinator.PubkeyData{
+						PubkeyPackage: publicKeyPackage,
+						InternalKey:   groupPublicKey,
+					},
+				},
+			}, nil
+		},
+	}
+
+	service := NewService(keystore, coordinator, nil, 0)
+	service.cachedPegout = pegout
+	service.doCommit(0, 2)
+
+	if !pegout.artifacts.HasCommitment(0) {
+		t.Fatal("commitment should be set")
+	}
+	commitments, err := helpers.DeserializeCommitments(pegout.artifacts.Commitments[0], len(pegout.inputs), helpers.FrostCommitmentLength)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(commitments) != len(pegout.commitments) {
+		t.Fatal("commitments should be equal")
+	}
+	for i, localCommitment := range pegout.commitments {
+		if !bytes.Equal(localCommitment, commitments[i]) {
+			t.Fatal("commitments should be equal")
+		}
+	}
+	t.Log("DoCommit done")
+}

--- a/oracle/internal/signing/service_test.go
+++ b/oracle/internal/signing/service_test.go
@@ -179,6 +179,9 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 				},
 			}, nil
 		},
+		SendSignaturesFunc: func(pegoutID uint64, validatorIdx uint16, signatures [][]byte) (*tlb.Transaction, error) {
+			return nil, nil
+		},
 	}
 
 	// Create service instance
@@ -212,6 +215,15 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 				}
 			}
 		})
+		t.Run("Nonces are different", func(t *testing.T) {
+			for i, localNonce := range pegout.nonces {
+				for j, nonce := range pegout.nonces {
+					if i != j && bytes.Equal(localNonce, nonce) {
+						t.Fatal("nonces should be different")
+					}
+				}
+			}
+		})
 
 		t.Run("Local and coordinator commitments are equal", func(t *testing.T) {
 			for i, localCommitment := range pegout.commitments {
@@ -234,7 +246,7 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 		return commitments
 	}
 
-	t.Run("doSign", func(t *testing.T) {
+	t.Run("doSign: deserialize commitments", func(t *testing.T) {
 		commitmentsFor1Serialized, err := helpers.SerializeCommitments(generateCommitments(1, 2), helpers.FrostCommitmentLength)
 		if err != nil {
 			t.Fatal(err)
@@ -260,8 +272,13 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 		})
 	})
 
-	t.Run("Cleanup nonces", func(t *testing.T) {
-		service.cleanupNonces()
+	t.Run("Cleanup nonces in doAggregate", func(t *testing.T) {
+		if service.cachedPegout.nonces == nil {
+			t.Fatal("inputs should be set")
+		}
+		service.cachedPegout.inputs = make([]pegoutcontract.TxInput, 0)
+		service.doAggregate(validatorIdx, publicKeyPackage)
+
 		if service.cachedPegout.nonces != nil {
 			t.Fatal("nonces should be nil")
 		}

--- a/oracle/internal/signing/service_test.go
+++ b/oracle/internal/signing/service_test.go
@@ -83,15 +83,18 @@ func generateFrostKey(minSigners uint16, maxSigners uint16) (map[uint16][]byte, 
 	return keyPackages, publicKeyPackage
 }
 
-func TestServiceGenerateCommitmentsForEachInput(t *testing.T) {
+func TestGenerateCommitmentsForEachInput(t *testing.T) {
 	maxSigners := uint16(3)
 	minSigners := uint16(2)
+
+	// Generate frost group key
 	keyPackages, publicKeyPackage := generateFrostKey(minSigners, maxSigners)
 	groupPublicKey, err := frost.ExtractPublicKeyFromPackage(publicKeyPackage)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// Prepare cached pegout
 	pegout := &CachedPegout{
 		ID:      1,
 		addrStr: address.NewAddress(0, 0, make([]byte, 32)).String(),
@@ -118,8 +121,12 @@ func TestServiceGenerateCommitmentsForEachInput(t *testing.T) {
 			ExpiredAt:       time.Now().Add(time.Minute),
 			SigningMask:     big.NewInt(7),
 		},
+		signingHashes: [][]byte{
+			make([]byte, 32),
+			make([]byte, 32),
+		},
 	}
-
+	// Create keystore mock
 	keystore := &keystore.KeystoreMock{
 		LoadSecretFunc: func(pubKey []byte) []byte {
 			return keyPackages[0]
@@ -174,24 +181,82 @@ func TestServiceGenerateCommitmentsForEachInput(t *testing.T) {
 		},
 	}
 
+	// Create service instance
 	service := NewService(keystore, coordinator, nil, 0)
 	service.cachedPegout = pegout
-	service.doCommit(0, 2)
+	validatorIdx := uint16(0)
 
-	if !pegout.artifacts.HasCommitment(0) {
-		t.Fatal("commitment should be set")
-	}
-	commitments, err := helpers.DeserializeCommitments(pegout.artifacts.Commitments[0], len(pegout.inputs), helpers.FrostCommitmentLength)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(commitments) != len(pegout.commitments) {
-		t.Fatal("commitments should be equal")
-	}
-	for i, localCommitment := range pegout.commitments {
-		if !bytes.Equal(localCommitment, commitments[i]) {
-			t.Fatal("commitments should be equal")
+	t.Run("doCommit", func(t *testing.T) {
+		service.doCommit(validatorIdx, minSigners)
+		t.Run("Check that commitment is set", func(t *testing.T) {
+			if !pegout.artifacts.HasCommitment(validatorIdx) {
+				t.Fatal("commitment should be set")
+			}
+		})
+		var commitments [][]byte
+		t.Run("Commitments are deserialized correctly", func(t *testing.T) {
+			commitments, err = helpers.DeserializeCommitments(pegout.artifacts.Commitments[validatorIdx], len(pegout.inputs), helpers.FrostCommitmentLength)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(commitments) != len(pegout.inputs) {
+				t.Fatal("commitments count should be equal to the number of inputs")
+			}
+		})
+		t.Run("Commitments are different", func(t *testing.T) {
+			for i, localCommitment := range pegout.commitments {
+				for j, commit := range pegout.commitments {
+					if i != j && bytes.Equal(localCommitment, commit) {
+						t.Fatal("commitments should be different")
+					}
+				}
+			}
+		})
+
+		t.Run("Local and coordinator commitments are equal", func(t *testing.T) {
+			for i, localCommitment := range pegout.commitments {
+				if !bytes.Equal(localCommitment, commitments[i]) {
+					t.Fatal("commitments should be equal")
+				}
+			}
+		})
+	})
+
+	generateCommitments := func(idx uint16, inputs uint16) [][]byte {
+		commitments := make([][]byte, inputs)
+		var err error
+		for i := range commitments {
+			_, commitments[i], err = frost.Commit(frost.NewPackage(keyPackages[idx]))
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
+		return commitments
 	}
-	t.Log("DoCommit done")
+
+	t.Run("doSign", func(t *testing.T) {
+		commitmentsFor1Serialized, err := helpers.SerializeCommitments(generateCommitments(1, 2), helpers.FrostCommitmentLength)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitmentsFor2Serialized, err := helpers.SerializeCommitments(generateCommitments(2, 2), helpers.FrostCommitmentLength)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pegout.artifacts.Commitments[1] = commitmentsFor1Serialized
+		pegout.artifacts.Commitments[2] = commitmentsFor2Serialized
+
+		t.Run("SignInput 0", func(t *testing.T) {
+			_, err = service.SignInput(validatorIdx, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+		t.Run("SignInput 1", func(t *testing.T) {
+			_, err = service.SignInput(validatorIdx, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
 }


### PR DESCRIPTION
16. Nonce reuse in the Oracle signing service leaks the group’s private key for
any pegout with three or more inputs
- Updated doCommit logic to generate nonces and commitments for every pegout input.
- Added `SerializeCommitments` and `DeserializeCommitments` functions to handle the serialization of input commitments.
- Updated `SignService` to manage commitments and nonces as slices of byte arrays, improving handling of multiple inputs.
- Refactored `doCommit`, `doSign`, and `doAggregate` methods to utilize the new commitment handling logic.
- Added cleanup of nonces in `doAggregate`.
- Removed load/store methods for nonces and commitments from keystore interface.
- Added tests.