### PR TITLE
TOB-TGBTC-8

### DIFF
--- a/lib/pkg/ton/coordinator/coordinator_contract.go
+++ b/lib/pkg/ton/coordinator/coordinator_contract.go
@@ -48,24 +48,28 @@ type Coordinator interface {
 
 	SendCommitments(
 		pegoutID uint64,
+		pegoutUntil int64,
 		validatorIdx uint16,
 		commitments []byte,
 	) (*tlb.Transaction, error)
 
 	SendSigningShare(
 		pegoutID uint64,
+		pegoutUntil int64,
 		validatorIdx uint16,
 		signingShares [][]byte,
 	) (*tlb.Transaction, error)
 
 	SendSignatures(
 		pegoutID uint64,
+		pegoutUntil int64,
 		validatorIdx uint16,
 		signatures [][]byte,
 	) (*tlb.Transaction, error)
 
 	SendSigningClaim(
 		pegoutID uint64,
+		pegoutUntil int64,
 		validatorIdx uint16,
 		culpritIdx uint16,
 	) (*tlb.Transaction, error)

--- a/lib/pkg/ton/coordinator/msgs.go
+++ b/lib/pkg/ton/coordinator/msgs.go
@@ -68,6 +68,7 @@ func BuildSendCommitmentsBody(ttl int64, req *CommitmentRequest) *cell.Cell {
 		MustStoreUInt(uint64(time.Now().Unix()+ttl), 32).
 		MustStoreUInt(uint64(req.ValidatorIdx), 16).
 		MustStoreUInt(req.PegoutID, 64).
+		MustStoreUInt(uint64(req.PegoutUntil), 32).
 		MustStoreRef(utils.SplitBytesToCells(req.Commitments)).
 		EndCell()
 }
@@ -86,6 +87,7 @@ func BuildSendSigningShareBody(ttl int64, req *SigningShareRequest) *cell.Cell {
 		MustStoreUInt(uint64(time.Now().Unix()+ttl), 32).
 		MustStoreUInt(uint64(req.ValidatorIdx), 16).
 		MustStoreUInt(req.PegoutID, 64).
+		MustStoreUInt(uint64(req.PegoutUntil), 32).
 		MustStoreRef(dict.AsCell()).
 		EndCell()
 }
@@ -104,6 +106,7 @@ func BuildSendSignaturesBody(ttl int64, req *SignaturesRequest) *cell.Cell {
 		MustStoreUInt(uint64(time.Now().Unix()+ttl), 32).
 		MustStoreUInt(uint64(req.ValidatorIdx), 16).
 		MustStoreUInt(req.PegoutID, 64).
+		MustStoreUInt(uint64(req.PegoutUntil), 32).
 		MustStoreRef(dict.AsCell()).
 		EndCell()
 }
@@ -114,6 +117,7 @@ func BuildSendSigningClaimBody(ttl int64, req *SigningClaimRequest) *cell.Cell {
 		MustStoreUInt(uint64(time.Now().Unix()+ttl), 32).
 		MustStoreUInt(uint64(req.ValidatorIdx), 16).
 		MustStoreUInt(req.PegoutID, 64).
+		MustStoreUInt(uint64(req.PegoutUntil), 32).
 		MustStoreUInt(uint64(req.culpritIdx), 16).
 		EndCell()
 }

--- a/lib/pkg/ton/coordinator/operations.go
+++ b/lib/pkg/ton/coordinator/operations.go
@@ -91,6 +91,7 @@ func (c *coordinatorContract) SendPubkeyPackage(
 
 func (c *coordinatorContract) SendCommitments(
 	PegoutID uint64,
+	PegoutUntil int64,
 	ValidatorIdx uint16,
 	Commitments []byte,
 ) (*tlb.Transaction, error) {
@@ -99,40 +100,43 @@ func (c *coordinatorContract) SendCommitments(
 	}
 	return c.sendBodyCell(BuildSendCommitmentsBody(
 		int64(c.ttl.Seconds()),
-		&CommitmentRequest{PegoutID, ValidatorIdx, Commitments},
+		&CommitmentRequest{PegoutID, PegoutUntil, ValidatorIdx, Commitments},
 	), "SendCommitments")
 }
 
 func (c *coordinatorContract) SendSigningShare(
 	PegoutID uint64,
+	PegoutUntil int64,
 	ValidatorIdx uint16,
 	SigningShares [][]byte,
 ) (*tlb.Transaction, error) {
 	return c.sendBodyCell(BuildSendSigningShareBody(
 		int64(c.ttl.Seconds()),
-		&SigningShareRequest{PegoutID, ValidatorIdx, SigningShares},
+		&SigningShareRequest{PegoutID, PegoutUntil, ValidatorIdx, SigningShares},
 	), "SendSigningShare")
 }
 
 func (c *coordinatorContract) SendSignatures(
 	PegoutID uint64,
+	PegoutUntil int64,
 	ValidatorIdx uint16,
 	Signatures [][]byte,
 ) (*tlb.Transaction, error) {
 	return c.sendBodyCell(BuildSendSignaturesBody(
 		int64(c.ttl.Seconds()),
-		&SignaturesRequest{PegoutID, ValidatorIdx, Signatures},
+		&SignaturesRequest{PegoutID, PegoutUntil, ValidatorIdx, Signatures},
 	), "SendSignatures")
 }
 
 func (c *coordinatorContract) SendSigningClaim(
 	PegoutID uint64,
+	PegoutUntil int64,
 	ValidatorIdx uint16,
 	culpritIdx uint16,
 ) (*tlb.Transaction, error) {
 	return c.sendBodyCell(BuildSendSigningClaimBody(
 		int64(c.ttl.Seconds()),
-		&SigningClaimRequest{PegoutID, ValidatorIdx, culpritIdx},
+		&SigningClaimRequest{PegoutID, PegoutUntil, ValidatorIdx, culpritIdx},
 	), "SendSigningClaim")
 }
 

--- a/lib/pkg/ton/coordinator/types.go
+++ b/lib/pkg/ton/coordinator/types.go
@@ -96,24 +96,28 @@ func (dkg *DKG) CheckVSetMask(validatorIdx uint16) bool {
 // CommitmentRequest represents a request to send commitments
 type CommitmentRequest struct {
 	PegoutID     uint64
+	PegoutUntil  int64
 	ValidatorIdx uint16
 	Commitments  []byte
 }
 
 type SigningShareRequest struct {
 	PegoutID      uint64
+	PegoutUntil   int64
 	ValidatorIdx  uint16
 	SigningShares [][]byte
 }
 
 type SignaturesRequest struct {
 	PegoutID     uint64
+	PegoutUntil  int64
 	ValidatorIdx uint16
 	Signatures   [][]byte
 }
 
 type SigningClaimRequest struct {
 	PegoutID     uint64
+	PegoutUntil  int64
 	ValidatorIdx uint16
 	culpritIdx   uint16
 }

--- a/oracle/internal/signing/logging.go
+++ b/oracle/internal/signing/logging.go
@@ -123,6 +123,10 @@ func (s *SignService) logSendSigningShare(pegoutID uint64, signShares [][]byte) 
 	infoEventWithPegoutID(pegoutID).Msgf("send %d signing shares", len(signShares))
 }
 
+func (s *SignService) logSendCommitmentsError(pegoutID uint64, err error) {
+	errorEventWithPegoutID(pegoutID).Err(err).Msg("failed to send commitments")
+}
+
 func (s *SignService) logSendSigningShareError(pegoutID uint64, err error) {
 	msg := helpers.HandleTvmError(err)
 	errorEventWithPegoutID(pegoutID).Err(err).Msg("failed to send signing share: " + msg)

--- a/oracle/internal/signing/service.go
+++ b/oracle/internal/signing/service.go
@@ -274,16 +274,8 @@ func (s *SignService) doCommit(
 		s.logError("failed to serialize commitments", err)
 		return false
 	}
-	s.logSendCommitments(pegout.ID)
-	if _, err := s.coordinator.SendCommitments(
-		pegout.ID,
-		validatorIdx,
-		packedCommitments,
-	); err != nil {
-		s.logError("failed to send commitments", err)
-	} else {
-		s.logCommitSent(pegout.ID)
-	}
+
+	s.sendCommitments(pegout, validatorIdx, packedCommitments)
 
 	return false
 }
@@ -337,16 +329,7 @@ func (s *SignService) doSign(
 		s.keyStore.StoreSigningShares(pegout.addrStr, signShares)
 	}
 
-	s.logSendSigningShare(pegout.ID, signShares)
-	if _, err := s.coordinator.SendSigningShare(
-		pegout.ID,
-		validatorIdx,
-		signShares,
-	); err != nil {
-		s.logSendSigningShareError(pegout.ID, err)
-	} else {
-		s.logSigningShareSent(pegout.ID)
-	}
+	s.sendSigningShares(pegout, validatorIdx, signShares)
 
 	return false
 }
@@ -370,14 +353,47 @@ func (s *SignService) doAggregate(
 		signatures = append(signatures, signature)
 	}
 
-	if _, err := s.coordinator.SendSignatures(
+	// Send signatures
+	s.SendSignatures(pegout, validatorIdx, signatures)
+}
+
+func (s *SignService) sendCommitments(pegout *CachedPegout, validatorIdx uint16, commitments []byte) {
+	s.logSendCommitments(pegout.ID)
+	if _, err := s.coordinator.SendCommitments(
 		pegout.ID,
+		pegout.artifacts.ExpiredAt.Unix(),
+		validatorIdx,
+		commitments,
+	); err != nil {
+		s.logSendCommitmentsError(pegout.ID, err)
+	} else {
+		s.logCommitSent(pegout.ID)
+	}
+}
+
+func (s *SignService) sendSigningShares(pegout *CachedPegout, validatorIdx uint16, signShares [][]byte) {
+	s.logSendSigningShare(pegout.ID, signShares)
+	if _, err := s.coordinator.SendSigningShare(
+		pegout.ID,
+		pegout.artifacts.ExpiredAt.Unix(),
+		validatorIdx,
+		signShares,
+	); err != nil {
+		s.logSendSigningShareError(pegout.ID, err)
+	} else {
+		s.logSigningShareSent(pegout.ID)
+	}
+}
+
+func (s *SignService) SendSignatures(pegout *CachedPegout, validatorIdx uint16, signatures [][]byte) {
+	_, err := s.coordinator.SendSignatures(
+		pegout.ID,
+		pegout.artifacts.ExpiredAt.Unix(),
 		validatorIdx,
 		signatures,
-	); err != nil {
+	)
+	if err != nil {
 		s.logSignatureSendError(err)
-	} else {
-		s.logSignatureSent(pegout.ID)
 	}
 }
 
@@ -520,6 +536,7 @@ func (s *SignService) executeClaim(pegout *CachedPegout, validatorIdx uint16, cu
 
 	if _, err := s.coordinator.SendSigningClaim(
 		pegout.ID,
+		pegout.artifacts.ExpiredAt.Unix(),
 		validatorIdx,
 		culpritIdx,
 	); err != nil {

--- a/oracle/internal/signing/service_test.go
+++ b/oracle/internal/signing/service_test.go
@@ -2,6 +2,7 @@ package signing
 
 import (
 	"bytes"
+	"crypto/rand"
 	"math/big"
 	"testing"
 	"time"
@@ -134,7 +135,7 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 	}
 
 	coordinator := &coordinator.CoordinatorMock{
-		SendCommitmentsFunc: func(pegoutID uint64, validatorIdx uint16, commitments []byte) (*tlb.Transaction, error) {
+		SendCommitmentsFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, commitments []byte) (*tlb.Transaction, error) {
 			if validatorIdx != 0 {
 				t.Fatal("validatorIdx should be 0")
 			}
@@ -171,7 +172,7 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 				},
 			}, nil
 		},
-		SendSignaturesFunc: func(pegoutID uint64, validatorIdx uint16, signatures [][]byte) (*tlb.Transaction, error) {
+		SendSignaturesFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, signatures [][]byte) (*tlb.Transaction, error) {
 			return nil, nil
 		},
 	}
@@ -277,4 +278,65 @@ func TestGenerateCommitmentsForEachInput(t *testing.T) {
 		// call again to be sure the code doesn't panic
 		service.cleanupNonces()
 	})
+}
+
+func TestPegoutUntil(t *testing.T) {
+	pegout := &CachedPegout{
+		ID:            1,
+		addrStr:       "",
+		inputs:        []pegoutcontract.TxInput{},
+		tx:            nil,
+		signingHashes: [][]byte{},
+		artifacts: &coordinator.PegoutRecord{
+			ExpiredAt:  time.Unix(100000000, 0),
+			ClaimsMask: big.NewInt(0),
+		},
+	}
+
+	validateExpiredAt := func(pegout *CachedPegout, pegoutUntil int64) {
+		if pegout.artifacts.ExpiredAt.Unix() != pegoutUntil {
+			t.Fatalf("Wrong pegoutUntil: expected %d, but got %d", pegout.artifacts.ExpiredAt.Unix(), pegoutUntil)
+		}
+	}
+
+	coordinator := &coordinator.CoordinatorMock{
+		SendCommitmentsFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, commitments []byte) (*tlb.Transaction, error) {
+			validateExpiredAt(pegout, pegoutUntil)
+			return nil, nil
+		},
+		SendSigningShareFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, signingShares [][]byte) (*tlb.Transaction, error) {
+			validateExpiredAt(pegout, pegoutUntil)
+			return nil, nil
+		},
+		SendSignaturesFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, signatures [][]byte) (*tlb.Transaction, error) {
+			validateExpiredAt(pegout, pegoutUntil)
+			return nil, nil
+		},
+		SendSigningClaimFunc: func(pegoutID uint64, pegoutUntil int64, validatorIdx uint16, culpritIdx uint16) (*tlb.Transaction, error) {
+			validateExpiredAt(pegout, pegoutUntil)
+			return nil, nil
+		},
+	}
+
+	service := NewService(nil, coordinator, nil, 0)
+	validatorIdx := uint16(0)
+
+	commitments := make([]byte, 32)
+	rand.Read(commitments)
+
+	service.sendCommitments(pegout, validatorIdx, commitments)
+
+	signShares := make([][]byte, 1)
+	signShares[0] = make([]byte, 32)
+	rand.Read(signShares[0])
+
+	service.sendSigningShares(pegout, validatorIdx, signShares)
+
+	signatures := make([][]byte, 1)
+	signatures[0] = make([]byte, 64)
+	rand.Read(signatures[0])
+
+	service.SendSignatures(pegout, validatorIdx, signatures)
+
+	service.executeClaim(pegout, validatorIdx, 1)
 }


### PR DESCRIPTION
* feat(coordinator): enhance coordinator contract methods to include pegoutUntil parameter

- Updated SendCommitments, SendSigningShare, SendSignatures, and SendSigningClaim methods to accept a new pegoutUntil parameter.
- Modified corresponding request structures (CommitmentRequest, SigningShareRequest, SignaturesRequest, SigningClaimRequest) to include pegoutUntil.
- Adjusted body building functions to store pegoutUntil in the transaction body.

* feat(oracle): streamline commitment and signing share methods to include pegoutUntil parameter

- Refactored sendCommitments and sendSigningShares methods to utilize pegoutUntil from CachedPegout artifacts.
- added  new TestPegoutUntil test to ensure correct handling of pegoutUntil value.