### PR TITLE
Fix ConnectSigner for pegout signing service

### DIFF
--- a/oracle/cmd/main.go
+++ b/oracle/cmd/main.go
@@ -86,16 +86,25 @@ func startAndWaitForStop() error {
 	// Coordinator contract
 	logger.Log.Info().Msgf("Create a new Coordinator contract wrapper with address `%s`", cfg.CoordinatorContractAddr)
 	apiCallTimeout := helpers.ParseIntWithDefaultVal(cfg.ApiCallTimeout, 30, "API call timeout")
-	coordinatorContract := coordinator.New(coordinatorContractAddr, tonClient, nil, ctx, apiCallTimeout)
 
 	// DKG service
 	fetchPeriod := helpers.ParseIntWithDefaultVal(cfg.FetchPeriod, 6, "DKG fetcher period")
 	sendStartDKGPeriod := helpers.ParseIntWithDefaultVal(cfg.SendStartDKGPeriod, 10, "SendStartDKG period")
-	dkgService := dkg.NewService(coordinatorContract, validator, fetchPeriod, sendStartDKGPeriod)
+	dkgService := dkg.NewService(
+		coordinator.New(coordinatorContractAddr, tonClient, nil, ctx, apiCallTimeout),
+		validator,
+		fetchPeriod,
+		sendStartDKGPeriod,
+	)
 
 	// FROST sign service
 	executeSignPeriod := helpers.ParseIntWithDefaultVal(cfg.ExecuteSignPeriod, 10, "ExecuteSign period")
-	signService := signing.NewService(keystore, coordinatorContract, tonClient, executeSignPeriod)
+	signService := signing.NewService(
+		keystore,
+		coordinator.New(coordinatorContractAddr, tonClient, nil, ctx, apiCallTimeout),
+		tonClient,
+		executeSignPeriod,
+	)
 
 	wg.Add(1)
 	go dkgService.Work(ctx, &wg, keystore)

--- a/oracle/internal/helpers.go
+++ b/oracle/internal/helpers.go
@@ -17,7 +17,9 @@ import (
 
 const (
 	ErrDkgClosed                       = 112
+	ErrInvalidSignature                = 113
 	ErrPackageAlreadyExist             = 114
+	ErrSignatureExists                 = 117
 	ErrCommitmentsThresholdReached     = 145
 	ErrDkgAlreadyExecuted              = 146
 	TvmExitCodeDifferentPubkeyPackages = 152
@@ -271,7 +273,7 @@ func HandleTvmError(tvmError error) string {
 	case 112:
 		return "Dkg closed"
 	case 113:
-		return "invalid signature"
+		return "Invalid signature"
 	case 114:
 		return "package already sent"
 	case 117:

--- a/oracle/internal/signing/logging.go
+++ b/oracle/internal/signing/logging.go
@@ -108,8 +108,14 @@ func (s *SignService) logSignaturesSent(pegoutID uint64, sentSignsCount uint16, 
 }
 
 func (s *SignService) logSignatureSendError(pegoutID uint64, err error) {
-	msg := helpers.HandleTvmError(err)
-	errorEventWithPegoutID(pegoutID).Err(err).Msg("failed to send signatures: " + msg)
+	errCode, _ := helpers.ExtractExitCode(err.Error())
+
+	if errCode == helpers.ErrSignatureExists {
+		infoEventWithPegoutID(pegoutID).Msg("Signature exists")
+	} else {
+		msg := helpers.HandleTvmError(err)
+		errorEventWithPegoutID(pegoutID).Err(err).Msg("failed to send signatures: " + msg)
+	}
 }
 
 func (s *SignService) logSignError(inputIndex int, err error) {

--- a/oracle/internal/signing/service.go
+++ b/oracle/internal/signing/service.go
@@ -228,6 +228,8 @@ func (s *SignService) execute(ctx context.Context, dkg *coordinator.DKG) {
 	pubkeyPackage := dkg.R3.Data.PubkeyPackage
 
 	// Check for signing restart
+	s.coordinator.ConnectSigner(s.sessionSigner)
+
 	if (unsignedPegout.ExpiredAt != time.Unix(0, 0)) && (unsignedPegout.ExpiredAt.Before(time.Now())) {
 		s.executeResetPegoutSigning(unsignedPegout.ID, validatorIdx)
 		s.cachePegoutClear()
@@ -243,8 +245,6 @@ func (s *SignService) execute(ctx context.Context, dkg *coordinator.DKG) {
 	if cachedPegout == nil {
 		panic("cached pegout is nil")
 	}
-
-	s.coordinator.ConnectSigner(s.sessionSigner)
 
 	minSigners, err := helpers.CalcMinSigners(dkg.MaxSigners)
 	if err != nil {
@@ -572,7 +572,7 @@ func (s *SignService) executeClaim(pegout *CachedPegout, validatorIdx uint16, cu
 	s.logExecuteClaim(pegout.ID)
 
 	if s.ClaimCompleted(pegout, validatorIdx) {
-		s.logMessage("claim completed")
+		s.logMessage("claim completed (it has already been sent)")
 		return
 	}
 


### PR DESCRIPTION
https://rsquad-blockchain-lab.atlassian.net/browse/TTBTC-684

* Fixed `coordinator.ConnectSigner` for session signer: moved connection before potential call to `executeResetPegoutSigning`.
* Created separate `coordinatorContract` instances for DKG and SignService to fix a potential race condition when both call `coordinator.ConnectSigner` on the same coordinator instance.