### PR TITLE
Add processing of new pegout commitment mask

### DIFF
--- a/indexer/internal/gql/ent_resolvers.go
+++ b/indexer/internal/gql/ent_resolvers.go
@@ -67,15 +67,3 @@ func (r *queryResolver) TonTxes(ctx context.Context, after *entgql.Cursor[int], 
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
 type queryResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//    it when you're done.
-//  - You have helper methods in this file. Move them out to keep these resolver files clean.
-/*
-	func (r *queryResolver) StateDkGs(ctx context.Context) ([]*generated.StateDKG, error) {
-	panic(fmt.Errorf("not implemented: StateDkGs - stateDkGs"))
-}
-*/

--- a/lib/pkg/ton/coordinator/getters.go
+++ b/lib/pkg/ton/coordinator/getters.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"math/big"
 	"time"
 
 	"github.com/rsquad/ton-teleport-btc-periphery/lib/pkg/logger"
@@ -288,7 +289,17 @@ func parseUnsignedPegouts(pegoutsCell *cell.Cell) ([]PegoutRecord, error) {
 		ExpiredAt := time.Unix(int64(value.MustLoadUInt(32)), 0)
 		SigningMask := value.MustLoadBigUInt(256)
 
-		CommitmentsMask := value.MustLoadSlice(256)
+		commitmentsMask := value.MustLoadBigUInt(256)
+		// Mask for lower 100 bits: (1 << 100) - 1
+		mask100 := new(big.Int).Lsh(big.NewInt(1), 100)
+		mask100.Sub(mask100, big.NewInt(1))
+
+		// CommitmentsMaskAccepted [0..99] bits
+		CommitmentsMaskAccepted := new(big.Int).And(commitmentsMask, mask100)
+		// CommitmentsMaskOther [100..199] bits
+		CommitmentsMaskOther := new(big.Int).Rsh(commitmentsMask, 100)
+		CommitmentsMaskOther.And(CommitmentsMaskOther, mask100)
+
 		value.MustLoadUInt(16)
 		commitmentsDict := value.MustLoadDict(16)
 		commitmentsPtr, err := parseddict.ParseDict(
@@ -348,7 +359,8 @@ func parseUnsignedPegouts(pegoutsCell *cell.Cell) ([]PegoutRecord, error) {
 			InternalKey,
 			IsAutopegout,
 			Commitments,
-			CommitmentsMask,
+			CommitmentsMaskAccepted,
+			CommitmentsMaskOther,
 			SigningShares,
 			SigningSharesMask,
 			Signatures,

--- a/lib/pkg/ton/coordinator/getters.go
+++ b/lib/pkg/ton/coordinator/getters.go
@@ -2,7 +2,6 @@ package coordinator
 
 import (
 	"context"
-	"math/big"
 	"time"
 
 	"github.com/rsquad/ton-teleport-btc-periphery/lib/pkg/logger"
@@ -289,17 +288,8 @@ func parseUnsignedPegouts(pegoutsCell *cell.Cell) ([]PegoutRecord, error) {
 		ExpiredAt := time.Unix(int64(value.MustLoadUInt(32)), 0)
 		SigningMask := value.MustLoadBigUInt(256)
 
-		commitmentsMask := value.MustLoadBigUInt(256)
-		// Mask for lower 100 bits: (1 << 100) - 1
-		mask100 := new(big.Int).Lsh(big.NewInt(1), 100)
-		mask100.Sub(mask100, big.NewInt(1))
-
-		// CommitmentsMaskAccepted [0..99] bits
-		CommitmentsMaskAccepted := new(big.Int).And(commitmentsMask, mask100)
-		// CommitmentsMaskOther [100..199] bits
-		CommitmentsMaskOther := new(big.Int).Rsh(commitmentsMask, 100)
-		CommitmentsMaskOther.And(CommitmentsMaskOther, mask100)
-
+		CommitmentsMaskAccepted := value.MustLoadBigUInt(128)
+		CommitmentsMaskOther := value.MustLoadBigUInt(128)
 		value.MustLoadUInt(16)
 		commitmentsDict := value.MustLoadDict(16)
 		commitmentsPtr, err := parseddict.ParseDict(

--- a/lib/pkg/ton/coordinator/types.go
+++ b/lib/pkg/ton/coordinator/types.go
@@ -152,7 +152,7 @@ type PegoutRecord struct {
 	SigningMask             *big.Int
 }
 
-func (p *PegoutRecord) HasCommitmentAccepted(idx uint16) bool {
+func (p *PegoutRecord) HasCommitment(idx uint16) bool {
 	_, exists := p.Commitments[idx]
 	return exists
 }

--- a/lib/pkg/ton/coordinator/types.go
+++ b/lib/pkg/ton/coordinator/types.go
@@ -134,26 +134,31 @@ type PegoutSignatures struct {
 }
 
 type PegoutRecord struct {
-	ID                uint64
-	PegoutAddress     *address.Address
-	InternalKey       []byte
-	IsAutopegout      bool
-	Commitments       map[uint16][]byte
-	CommitmentsMask   []byte
-	SigningShares     map[uint16]map[uint16][]byte
-	SigningSharesMask []byte
-	Signatures        PegoutSignatures
-	ClaimsMask        *big.Int
-	ClaimsCount       uint16
-	ClaimsCounters    map[uint16]uint16
-	MaxSigners        uint16
-	ExpiredAt         time.Time
-	SigningMask       *big.Int
+	ID                      uint64
+	PegoutAddress           *address.Address
+	InternalKey             []byte
+	IsAutopegout            bool
+	Commitments             map[uint16][]byte
+	CommitmentsMaskAccepted *big.Int
+	CommitmentsMaskOther    *big.Int
+	SigningShares           map[uint16]map[uint16][]byte
+	SigningSharesMask       []byte
+	Signatures              PegoutSignatures
+	ClaimsMask              *big.Int
+	ClaimsCount             uint16
+	ClaimsCounters          map[uint16]uint16
+	MaxSigners              uint16
+	ExpiredAt               time.Time
+	SigningMask             *big.Int
 }
 
-func (p *PegoutRecord) HasCommitment(idx uint16) bool {
+func (p *PegoutRecord) HasCommitmentAccepted(idx uint16) bool {
 	_, exists := p.Commitments[idx]
 	return exists
+}
+
+func (p *PegoutRecord) HasCommitmentOther(idx uint16) bool {
+	return p.CommitmentsMaskOther.Bit(int(idx)) != 0
 }
 
 func (p *PegoutRecord) CommitmentsCount() uint16 {

--- a/oracle/internal/signing/logging.go
+++ b/oracle/internal/signing/logging.go
@@ -95,6 +95,10 @@ func (s *SignService) logMinimalCommitmentsReached(pegout *CachedPegout, minSign
 	infoEventWithPegoutID(pegout.ID).Msgf("Minimal required number of Commitments is reached (ready %d of %d)", pegout.artifacts.CommitmentsCount(), minSigners)
 }
 
+func (s *SignService) logHasCommitmentOther(pegout *CachedPegout, minSigners uint16) {
+	infoEventWithPegoutID(pegout.ID).Msgf("This orace sent commitment, but minimal required number of Commitments is reached (ready %d of %d)", pegout.artifacts.CommitmentsCount(), minSigners)
+}
+
 func (s *SignService) logMinimalCommitmentsWaitingForOtherOracles(pegout *CachedPegout, minSigners uint16) {
 	infoEventWithPegoutID(pegout.ID).Msgf("Waiting for other oracles to send their Commitments (ready %d of %d)", pegout.artifacts.CommitmentsCount(), minSigners)
 }

--- a/oracle/internal/signing/logging.go
+++ b/oracle/internal/signing/logging.go
@@ -96,7 +96,7 @@ func (s *SignService) logMinimalCommitmentsReached(pegout *CachedPegout, minSign
 }
 
 func (s *SignService) logHasCommitmentOther(pegout *CachedPegout, minSigners uint16) {
-	infoEventWithPegoutID(pegout.ID).Msgf("This orace sent commitment, but minimal required number of Commitments is reached (ready %d of %d)", pegout.artifacts.CommitmentsCount(), minSigners)
+	infoEventWithPegoutID(pegout.ID).Msgf("Commitment is accepted but oracle will not participate in signing - commitment threshold is reached (%d of %d)", pegout.artifacts.CommitmentsCount(), minSigners)
 }
 
 func (s *SignService) logMinimalCommitmentsWaitingForOtherOracles(pegout *CachedPegout, minSigners uint16) {

--- a/oracle/internal/signing/service.go
+++ b/oracle/internal/signing/service.go
@@ -270,7 +270,7 @@ func (s *SignService) doCommit(
 	pegout := s.cachedPegout
 	s.logCommitPegout(pegout.ID)
 
-	if pegout.artifacts.HasCommitment(validatorIdx) {
+	if pegout.artifacts.HasCommitmentAccepted(validatorIdx) {
 		s.logMessage("Commitment already exists")
 
 		if pegout.artifacts.CommitmentsCount() >= minSigners {
@@ -280,6 +280,11 @@ func (s *SignService) doCommit(
 			s.logMinimalCommitmentsWaitingForOtherOracles(pegout, minSigners)
 			return false
 		}
+	}
+
+	if pegout.artifacts.HasCommitmentOther(validatorIdx) {
+		s.logHasCommitmentOther(pegout, minSigners)
+		return false
 	}
 
 	err := s.generateCommitments()
@@ -301,7 +306,7 @@ func (s *SignService) doSign(
 	pegout := s.cachedPegout
 	s.logSignPegout(pegout.ID)
 
-	if !pegout.artifacts.HasCommitment(validatorIdx) {
+	if !pegout.artifacts.HasCommitmentAccepted(validatorIdx) {
 		s.logErrNoOracleCommitments(pegout.ID)
 		return false
 	}

--- a/oracle/internal/signing/service.go
+++ b/oracle/internal/signing/service.go
@@ -270,7 +270,7 @@ func (s *SignService) doCommit(
 	pegout := s.cachedPegout
 	s.logCommitPegout(pegout.ID)
 
-	if pegout.artifacts.HasCommitmentAccepted(validatorIdx) {
+	if pegout.artifacts.HasCommitment(validatorIdx) {
 		s.logMessage("Commitment already exists")
 
 		if pegout.artifacts.CommitmentsCount() >= minSigners {
@@ -306,7 +306,7 @@ func (s *SignService) doSign(
 	pegout := s.cachedPegout
 	s.logSignPegout(pegout.ID)
 
-	if !pegout.artifacts.HasCommitmentAccepted(validatorIdx) {
+	if !pegout.artifacts.HasCommitment(validatorIdx) {
 		s.logErrNoOracleCommitments(pegout.ID)
 		return false
 	}


### PR DESCRIPTION
Upgrade the Oracle pegout signing round. Add processing for a new mask that distinguishes between oracles included in the 2/3 quorum and those that attempted to send a commitment after the min_signers threshold was already reached. This new mask will be used in the metrics.

Contracts PR: https://github.com/RSquad/ton-teleport-btc-contracts/pull/91